### PR TITLE
Fix for `get_coding_ssm_status` function

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -594,6 +594,7 @@ intersect_maf = function(maf1,
 #' @param maf_path If the status of coding SSM should be tabulated from a custom maf file, provide path to the maf in this argument. The default is set to NULL.
 #' @param maf_data Either a maf loaded from disk or from the database using a get_ssm function.
 #' @param include_hotspots Logical parameter indicating whether hotspots object should also be tabulated. Default is TRUE.
+#' @param keep_multihit_hotspot Logical parameter indicating whether to keep the gene annotation as mutated when the gene has both hot spot and non-hotspot mutation. Default is FALSE.
 #' @param recurrence_min Integer value indicating minimal recurrence level.
 #' @param seq_type The seq_type you want back, default is genome.
 #' @param projection Specify projection (grch37 or hg38) of mutations. Default is grch37.

--- a/man/get_coding_ssm_status.Rd
+++ b/man/get_coding_ssm_status.Rd
@@ -13,6 +13,7 @@ get_coding_ssm_status(
   maf_path = NULL,
   maf_data,
   include_hotspots = TRUE,
+  keep_multihit_hotspot = FALSE,
   recurrence_min = 5,
   seq_type = "genome",
   projection = "grch37",
@@ -38,6 +39,8 @@ get_coding_ssm_status(
 \item{maf_data}{Either a maf loaded from disk or from the database using a get_ssm function.}
 
 \item{include_hotspots}{Logical parameter indicating whether hotspots object should also be tabulated. Default is TRUE.}
+
+\item{keep_multihit_hotspot}{Logical parameter indicating whether to keep the gene annotation as mutated when the gene has both hot spot and non-hotspot mutation. Default is FALSE.}
 
 \item{recurrence_min}{Integer value indicating minimal recurrence level.}
 


### PR DESCRIPTION
This PR is a fix for the issue #181 . Minimal reproducible example for the new functionality:

```

library(tidyverse)
library(vroom)

setwd("~/GAMBLR/")

devtools::load_all()

# get meta
meta <- get_gambl_metadata(
    case_set = "DLBCL-unembargoed"
)

# get mutations
maf <- get_coding_ssm(
        these_samples_metadata = meta
    ) %>%
    dplyr::filter(
        Hugo_Symbol == "CREBBP" # subset to example gene
    )

new_way <- get_coding_ssm_status(
        gene_symbols = "CREBBP",
        maf_data = maf,
        these_samples_metadata = meta
    )

new_way_multihit <- get_coding_ssm_status(
        gene_symbols = "CREBBP",
        maf_data = maf,
        keep_multihit_hotspot = TRUE,
        these_samples_metadata = meta
    )

setdiff(new_way_multihit, new_way)
```
This will show difference in 7 samples where the `CREBBP` is actually multihit and therefore both hot spot and non hot spot should be annotated.