### PR TITLE
Fix error in gene_to_region function

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -384,9 +384,9 @@ gene_to_region = function(gene_symbol,
   region = dplyr::select(gene_coordinates, chromosome, start, end, gene_name, hugo_symbol, ensembl_gene_id) %>%
     as.data.frame() %>%
     dplyr::arrange(chromosome, start) %>%
-    dplyr::filter(chromosome %in% chr_select) %>%
-    mutate_all(na_if,"") %>%
-    distinct(.keep_all = TRUE)
+    dplyr::filter(chromosome %in% chr_select)
+  region[region == ""] = NA
+  region = distinct(region, .keep_all = TRUE)
 
   if(return_as == "bed"){
     #return one-row data frame with first 4 standard BED columns. TODO: Ideally also include strand if we have access to it in the initial data frame


### PR DESCRIPTION
I fixed an error when running the `gene_to_region` function. 

Example of a code to reproduce the error:
``myc_region = gene_to_region(gene_symbol = "MYC", genome_build = "grch37", return_as = "region")``

Error message:
``Can't convert `y` <character> to match type of `x` <double>.``

The code `mutate_all(na_if,"")` ([see line inside the function](https://github.com/morinlab/GAMBLR/blob/master/R/utilities.R#L388)) was changed to avoid incompatibilities between arguments `x` and `y` of function `na_if`.