### PR TITLE
Fix error in gene_to_region function

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -384,9 +384,9 @@ gene_to_region = function(gene_symbol,
   region = dplyr::select(gene_coordinates, chromosome, start, end, gene_name, hugo_symbol, ensembl_gene_id) %>%
     as.data.frame() %>%
     dplyr::arrange(chromosome, start) %>%
-    dplyr::filter(chromosome %in% chr_select) %>%
-    mutate_all(na_if,"") %>%
-    distinct(.keep_all = TRUE)
+    dplyr::filter(chromosome %in% chr_select)
+  region[region == ""] = NA
+  region = distinct(region, .keep_all = TRUE)
 
   if(return_as == "bed"){
     #return one-row data frame with first 4 standard BED columns. TODO: Ideally also include strand if we have access to it in the initial data frame


### PR DESCRIPTION
In this pull request, I fixed an error in the `gene_to_region` function.

Example of a code to reproduce the error:
```
library(GAMBLR)
library(tidyverse)
myc_region = gene_to_region(gene_symbol = "MYC", genome_build = "grch37", return_as = "region")
```

Error message:
`Can't convert `y` <character> to match type of `x` <double>.`

The code `mutate_all(na_if,"")` ([see line inside the function](https://github.com/morinlab/GAMBLR/blob/master/R/utilities.R#L388)) was changed to avoid incompatibilities between arguments `x` and `y` of function `na_if`.

# Pull Request Checklists

### Required

- [ ] I tested the new code for my use case (please provide a reproducible example of how you tested the new functionality)

```
library(GAMBLR)
library(tidyverse)

myc_region = gene_to_region(gene_symbol = "MYC", genome_build = "grch37", return_as = "region")
```

- [ ] I ensured all dplyr functions that commonly conflict with other packages are fully qualified. 

This can be checked and addressed by running `check_functions.pl` and responding to the prompts. Test your code _after_ you do this.

## Checklist for changes to existing code

- [ ] I tested the new code for compatibility with existing functionality in the Master branch (please provide a reprex of how you tested the original functionality)
