### PR TITLE
Fix error in get_ssm_by_samples function

### DIFF
--- a/R/database.R
+++ b/R/database.R
@@ -68,8 +68,6 @@ get_excluded_samples = function(tool_name = "slms-3"){
 #' @export
 #'
 #' @examples
-#' library(parallel)
-#'
 #' #example 1, using a vector of patient IDs.
 #' patients = c("00-14595", "00-15201", "01-12047")
 #' patients_maf = get_ssm_by_patients(these_patient_ids = patients,
@@ -172,8 +170,6 @@ get_ssm_by_patients = function(these_patient_ids,
 #' @export
 #'
 #' @examples
-#' library(parallel)
-#'
 #' #examples using the these_sample_ids parameter.
 #' sample_ssms = get_ssm_by_samples(these_sample_ids = c("HTMCP-01-06-00485-01A-01D",
 #'                                                       "14-35472_tumorA",
@@ -336,7 +332,7 @@ get_ssm_by_samples = function(these_sample_ids,
           maf_df_list[[this_sample]]=maf_df
         }
       }else{
-        maf_df_list = mclapply(these_sample_ids,function(x){get_ssm_by_sample(
+        maf_df_list = parallel::mclapply(these_sample_ids,function(x){get_ssm_by_sample(
         this_sample_id=x,
         these_samples_metadata = these_samples_metadata,
         tool_name = tool_name,

--- a/man/get_ssm_by_patients.Rd
+++ b/man/get_ssm_by_patients.Rd
@@ -59,8 +59,6 @@ Is this function not what you are looking for? Try one of the following, similar
 \link{get_ssm_by_sample}, \link{get_ssm_by_samples}, \link{get_ssm_by_region}, \link{get_ssm_by_regions}
 }
 \examples{
-library(parallel)
-
 #example 1, using a vector of patient IDs.
 patients = c("00-14595", "00-15201", "01-12047")
 patients_maf = get_ssm_by_patients(these_patient_ids = patients,

--- a/man/get_ssm_by_samples.Rd
+++ b/man/get_ssm_by_samples.Rd
@@ -64,8 +64,6 @@ Is this function not what you are looking for? Try one of the following, similar
 \link{get_coding_ssm_status}, \link{get_ssm_by_patients}, \link{get_ssm_by_sample}, \link{get_ssm_by_region}, \link{get_ssm_by_regions}
 }
 \examples{
-library(parallel)
-
 #examples using the these_sample_ids parameter.
 sample_ssms = get_ssm_by_samples(these_sample_ids = c("HTMCP-01-06-00485-01A-01D",
                                                       "14-35472_tumorA",


### PR DESCRIPTION
`get_ssm_by_samples` function uses `parallel::mclapply` internally. But it neither import `mclapply` nor add `parallel::` prefix to `mclapply`. Hence, the error 

```
could not find function "mclapply"
```

may be returned (which could be avoided by running `library(parallel)` before calling `get_ssm_by_samples`). 

Other functions that use `get_ssm_by_samples` internally (e.g. `get_ssm_by_patients`) return the same error.

Add `parallel::` prefix to `mclapply`.

# Pull Request Checklists

## Checklist for all PRs

### Required

- [x] I tested the new code for my use case (please provide a reproducible example of how you tested the new functionality)

```
library(GAMBLR)

#set sample IDs
these_samples = c("HTMCP-01-06-00485-01A-01D", 
                  "14-35472_tumorA", 
                  "14-35472_tumorB")

#get_ssm_by_samples
these_samples_ssm = get_ssm_by_samples(these_sample_ids = these_samples,
                                       projection = "grch37",
                                       seq_type = "genome")

#set patient IDs
these_patients = c("00-14595", 
                   "00-15201", 
                   "01-12047")

#get_ssm_by_patients
these_patients_ssm = get_ssm_by_patients(these_patient_ids = these_patients,
                                         seq_type = "genome",
                                         projection = "grch37")
```
Visualization of the `these_samples_ssm` object:

```
> head(these_samples_ssm, 3)
   Hugo_Symbol Entrez_Gene_Id Center NCBI_Build Chromosome Start_Position
1:     Unknown              0      .     GRCh37          1        5507023
2:      CAMTA1              0      .     GRCh37          1        7304379
3:        PER3              0      .     GRCh37          1        7888519
   End_Position Strand Variant_Classification Variant_Type Reference_Allele
1:      5507023      +                    IGR          SNP                C
2:      7304379      +                 Intron          SNP                G
3:      7888519      +                 Intron          SNP                G
   Tumor_Seq_Allele1 Tumor_Seq_Allele2 dbSNP_RS dbSNP_Val_Status
1:                 C                 G    novel               NA
2:                 G                 A    novel               NA
3:                 G                 A    novel               NA
        Tumor_Sample_Barcode Matched_Norm_Sample_Barcode Match_Norm_Seq_Allele1
1: HTMCP-01-06-00485-01A-01D   HTMCP-01-06-00485-12B-01D                      C
2: HTMCP-01-06-00485-01A-01D   HTMCP-01-06-00485-12B-01D                      G
3: HTMCP-01-06-00485-01A-01D   HTMCP-01-06-00485-12B-01D                      G
   Match_Norm_Seq_Allele2 Tumor_Validation_Allele1 Tumor_Validation_Allele2
1:                      C                       NA                       NA
2:                      G                       NA                       NA
3:                      G                       NA                       NA
   Match_Norm_Validation_Allele1 Match_Norm_Validation_Allele2
1:                            NA                            NA
2:                            NA                            NA
3:                            NA                            NA
   Verification_Status Validation_Status Mutation_Status Sequencing_Phase
1:                  NA                NA              NA               NA
2:                  NA                NA              NA               NA
3:                  NA                NA              NA               NA
   Sequence_Source Validation_Method Score BAM_File Sequencer Tumor_Sample_UUID
1:              NA                NA    NA       NA        NA                NA
2:              NA                NA    NA       NA        NA                NA
3:              NA                NA    NA       NA        NA                NA
   Matched_Norm_Sample_UUID         HGVSc HGVSp HGVSp_Short   Transcript_ID
1:                       NA                                                
2:                       NA c.303-5172G>A                   ENST00000303635
3:                       NA c.2862+644G>A                   ENST00000361923
   Exon_Number t_depth t_ref_count t_alt_count n_depth n_ref_count n_alt_count
1:                  66          33          33      40          40           0
2:                  74          37          36      34          34           0
3:                  70          29          41      33          33           0
```




- [x] I ensured all dplyr functions that commonly conflict with other packages are fully qualified. 


- [x] I generated the documentation and checked for errors relating to the **changed** function (e.g. `devtools::document()`) and added `NAMESPACE` and all other modified files in the root directory and under `man`. 

- [ ] I have rebuilt the site with `pkgdown::build_site(lazy = TRUE)` to reflect any updated package documentation.


### Optional but preferred with PRs

## Checklist for New Functions

### Required


- [x] **I changed an existing function and now** it uses a library that isn't already a dependency of GAMBLR and I made the package aware of this dependency using the function documentation `importFrom` statement. 

