### PR TITLE
fix get_cn_states output for missing samples

### DIFF
--- a/man/get_cn_states.Rd
+++ b/man/get_cn_states.Rd
@@ -11,7 +11,8 @@ get_cn_states(
   these_samples_metadata,
   this_seq_type = "genome",
   all_cytobands = FALSE,
-  use_cytoband_name = FALSE
+  use_cytoband_name = FALSE,
+  missing_data_as_diploid = FALSE
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ get_cn_states(
 \item{all_cytobands}{Include all cytobands, default is set to FALSE. Currently only supports hg19.}
 
 \item{use_cytoband_name}{Use cytoband names instead of region names, e.g p36.33.}
+
+\item{missing_data_as_diploid}{Fill in any sample/region combinations with missing data as diploid (e.g., CN counts like 2). Default is FALSE.}
 }
 \value{
 Copy number matrix.


### PR DESCRIPTION
This PR addresses the issue [#207](https://github.com/morinlab/GAMBLR/issues/207) - `get_cn_states()` output is misleading for missing samples.

# Pull Request Checklists

## Checklist for all PRs

### Required

- [x] I tested the new code for my use case (please provide a reproducible example of how you tested the new functionality)

Kostia's examples
```
my_regions <- grch37_lymphoma_genes_bed %>%
  head %>%
  mutate(region = paste0(
    chromosome_name,
    ":",
    start_position,
    "-",
    end_position
  )) %>%
  pull(region)

my_meta <- get_gambl_metadata() %>%
  filter(sample_id %in% c(
    "10-18191T", # This is chromium sample omitted from CNV workflows and missing the CNV results
    "HTMCP-01-06-00485-01A-01D", # Some random ids
    "012-19-01TD"
  )
  )

# More wild example where one of the IDs is clobbered (but keeping 012-19-01TD sample)
clobbered_meta_4_samples <- my_meta %>%
  slice( c(1, 1:3) ) %>% 
  mutate(sample_id = c("Imaginary_sample", .$sample_id[2:4]))

get_cn_states(
  regions_list = my_regions,
  these_samples_metadata = clobbered_meta_4_samples
)
#                           1:2487078-2496821 1:6581407-6614595 1:6650784-6674667 1:9711790-9789172 1:11166592-11322564 1:12227060-12269285                                                                            
# 10-18191T                                NA                NA                NA                NA                  NA                  NA
# Imaginary_sample                         NA                NA                NA                NA                  NA                  NA
# 012-19-01TD                               2                 1                 1                 1                   1                   2
# HTMCP-01-06-00485-01A-01D                 2                 2                 2                 2                   2                   2

get_cn_states(
  regions_list = my_regions,
  these_samples_metadata = clobbered_meta_4_samples,
  missing_data_as_diploid = TRUE
)
#                           1:2487078-2496821 1:6581407-6614595 1:6650784-6674667 1:9711790-9789172 1:11166592-11322564 1:12227060-12269285                                                                            
# 10-18191T                                 2                 2                 2                 2                   2                   2
# Imaginary_sample                          2                 2                 2                 2                   2                   2
# 012-19-01TD                               2                 1                 1                 1                   1                   2
# HTMCP-01-06-00485-01A-01D                 2                 2                 2                 2                   2                   2
```
All examples from get_cn_states documentation
```
#basic usage, generic lymphoma gene list
cn_matrix = get_cn_states(regions_bed=grch37_lymphoma_genes_bed)

myc_region <- gene_to_region(
 gene_symbol = "MYC",
 genome_build = "grch37",
 return_as = "region"
)

single_gene_cn <- get_cn_states(
 regions_list = myc_region,
 region_names = "MYC"
)

# For capture
single_gene_cn <- get_cn_states(
 regions_list = myc_region,
 region_names = "MYC",
 this_seq_type = "capture"
)
```

- [x] I generated the documentation and checked for errors relating to the new function (e.g. `devtools::document()`) and added `NAMESPACE` and all other modified files in the root directory and under `man`. 

## Checklist for changes to existing code

- [x] I added/removed arguments to a function and updated documentation for all changed/new arguments

- [x] I tested the new code for compatibility with existing functionality in the Master branch (please provide a reprex of how you tested the original functionality)

`get_gene_cn_and_expression` is the only function that uses `get_cn_states` internally.
```
> MYC_cn_expression = get_gene_cn_and_expression("MYC")
# [1] "grep -w -F -e Hugo_Symbol -e MYC /projects/nhl_meta_analysis_scratch/gambl/results_local/icgc_dart/DESeq2-0.0_salmon-1.0/mrna--gambl-icgc-all/vst-matrix-Hugo_Symbol_tidy.tsv"

> MYC_cn_expression
# # A tibble: 1,671 × 113
# compression bam_available patient_id sample_id       seq_type capture_space genome_build
# <chr>       <lgl>         <chr>      <chr>           <chr>    <chr>         <chr>       
#   1 bam         TRUE          00-14595   00-14595_tumorA genome   none          grch37      
# 2 cram        TRUE          00-14595   00-14595_tumorB genome   none          grch37      
# 3 cram        TRUE          00-14595   00-14595_tumorC genome   none          grch37      
# 4 bam         TRUE          00-14595   00-14595_tumorD genome   none          grch37      
# 5 cram        TRUE          00-15201   00-15201_tumorA genome   none          grch37      
# 6 cram        TRUE          00-15201   00-15201_tumorB genome   none          grch37      
# 7 bam         TRUE          00-16220   00-16220_tumorB genome   none          grch37      
# 8 cram        TRUE          00-20702   00-20702T       genome   none          grch37      
# 9 cram        TRUE          00-23442   00-23442_tumorA genome   none          grch37      
# 10 cram        TRUE          00-23442   00-23442_tumorB genome   none          grch37      
# # ℹ 1,661 more rows
# # ℹ 106 more variables: tissue_status <chr>, cohort <chr>, library_id <chr>, pathology <chr>,
# #   time_point <chr>, protocol <chr>, ffpe_or_frozen <chr>, read_length <dbl>,
# #   strandedness <chr>, seq_source_type <chr>, EBV_status_inf <chr>, link_name <chr>,
# #   data_path <chr>, unix_group <chr>, biopsy_id <chr>, fastq_link_name <chr>,
# #   fastq_data_path <chr>, COO_consensus <chr>, DHITsig_consensus <chr>,
# #   COO_PRPS_class <chr>, DHITsig_PRPS_class <chr>, DLBCL90_dlbcl_call <chr>, …
# # ℹ Use `print(n = ...)` to see more rows, and `colnames()` to see all variable names

```
