### PR TITLE
Hot-fixes

### DIFF
--- a/R/annotation.R
+++ b/R/annotation.R
@@ -173,7 +173,7 @@ annotate_ssm_blacklist = function(mutations_df,
 #'
 #' @examples
 #' \dontrun{
-#' my_segs = get_sample_cn_segments(this_sample_id = "HTMCP-01-06-00422-01A-01D")
+#' my_segs = get_sample_cn_segments(these_sample_ids = "HTMCP-01-06-00422-01A-01D")
 #' annotated = annotate_recurrent_cnv(seg_df = my_segs)
 #' }
 #' 
@@ -291,7 +291,7 @@ annotate_driver_ssm = function(maf_df,
 
   #get the gene list if missing
   if(missing(driver_genes)){
-    driver_genes = lymphoma_genes[which(lymphoma_genes[[lymphoma_type]] == TRUE),] %>%
+    driver_genes = GAMBLR.data::lymphoma_genes_lymphoma_genes_v0.0[which(GAMBLR.data::lymphoma_genes_lymphoma_genes_v0.0[[lymphoma_type]] == TRUE),] %>%
       pull(Gene)
 
     ngene = length(driver_genes)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -2127,7 +2127,7 @@ assign_cn_to_ssm = function(this_sample_id,
     data.table::setkey(seg_sample, Chromosome, Start_Position, End_Position)
     a = data.table::as.data.table(maf_sample)
   }else{
-    seg_sample = get_sample_cn_segments(this_sample_id = this_sample_id, this_seq_type = this_seq_type) %>%
+    seg_sample = get_sample_cn_segments(these_sample_ids = this_sample_id, this_seq_type = this_seq_type) %>%
       dplyr::mutate(size = end - start) %>%
       dplyr::filter(size > 100) %>%
       dplyr::mutate(chrom = gsub("chr", "", chrom)) %>%
@@ -3867,8 +3867,7 @@ collate_pga <- function(
 
     # Get the CN segments
     multi_sample_seg <- get_sample_cn_segments(
-        sample_list = these_samples_metadata$sample_id,
-        multiple_samples = TRUE,
+        these_samples_metadata = these_samples_metadata$sample_id,
         this_seq_type = this_seq_type
     ) %>%
     dplyr::rename("sample" = "ID")
@@ -3942,7 +3941,7 @@ standardize_chr_prefix = function(incoming_vector,
 #' @export
 #'
 #' @examples
-#' sample_seg = get_sample_cn_segments(this_sample_id = "14-36022T")
+#' sample_seg = get_sample_cn_segments(these_sample_ids = "14-36022T")
 #' sample_seg = dplyr::rename(sample_seg, "sample" = "ID")
 #'
 #' calculate_pga(this_seg = sample_seg)
@@ -3950,10 +3949,10 @@ standardize_chr_prefix = function(incoming_vector,
 #' calculate_pga(this_seg = sample_seg,
 #'               exclude_sex = FALSE)
 #'
-#' one_sample = get_sample_cn_segments(this_sample_id = "14-36022T")
+#' one_sample = get_sample_cn_segments(these_sample_ids = "14-36022T")
 #' one_sample = dplyr::rename(one_sample, "sample" = "ID")
 #'
-#' another_sample = get_sample_cn_segments(this_sample_id = "BLGSP-71-21-00243-01A-11E")
+#' another_sample = get_sample_cn_segments(these_sample_ids = "BLGSP-71-21-00243-01A-11E")
 #' another_sample = dplyr::rename(another_sample, "sample" = "ID")
 #'
 #' multi_sample_seg = rbind(one_sample, another_sample)
@@ -4099,15 +4098,15 @@ calculate_pga = function(this_seg,
 #' @export
 #'
 #' @examples
-#' sample_seg = get_sample_cn_segments(this_sample_id = "14-36022T")
+#' sample_seg = get_sample_cn_segments(these_sample_ids = "14-36022T")
 #' sample_seg = dplyr::rename(sample_seg, "sample" = "ID")
 #'
 #' adjust_ploidy(this_seg = sample_seg)
 #'
-#' one_sample = get_sample_cn_segments(this_sample_id = "14-36022T")
+#' one_sample = get_sample_cn_segments(these_sample_ids = "14-36022T")
 #' one_sample = dplyr::rename(one_sample, "sample" = "ID")
 #'
-#' another_sample = get_sample_cn_segments(this_sample_id = "BLGSP-71-21-00243-01A-11E")
+#' another_sample = get_sample_cn_segments(these_sample_ids = "BLGSP-71-21-00243-01A-11E")
 #' another_sample = dplyr::rename(another_sample, "sample" = "ID")
 #'
 #' multi_sample_seg = rbind(one_sample, another_sample)
@@ -4225,9 +4224,8 @@ adjust_ploidy = function(this_seg,
 #' @noRd
 #'
 #' @examples
-#' cn_states = get_sample_cn_segments(multiple_samples = TRUE,
-#'                                    sample_list = c("00-15201_tumorA",
-#'                                                    "HTMCP-01-06-00422-01A-01D"),
+#' cn_states = get_sample_cn_segments(these_sample_ids = c("00-15201_tumorA",
+#'                                                         "HTMCP-01-06-00422-01A-01D"),
 #'                                    streamlined = FALSE)
 #'
 #' subset_cnstates(cn_segments = cn_states,
@@ -4370,8 +4368,7 @@ cnvKompare = function(patient_id,
       dplyr::mutate(CN = (2 * 2 ^ log.ratio))
   } else {
     message("Retreiving the CNV data using GAMBLR ...")
-    these_samples_seg = get_sample_cn_segments(multiple_samples = TRUE,
-                                               sample_list = these_sample_ids,
+    these_samples_seg = get_sample_cn_segments(these_sample_ids = these_sample_ids,
                                                from_flatfile = TRUE,
                                                projection = projection,
                                                with_chr_prefix = TRUE,

--- a/R/viz.R
+++ b/R/viz.R
@@ -1241,7 +1241,7 @@ plot_sample_circos = function(this_sample_id,
   }
   if(missing(cnv_df)){
     cnv_df = get_sample_cn_segments(
-      this_sample_id = this_sample_id,
+      these_sample_ids = this_sample_id,
       with_chr_prefix = TRUE,
       this_seq_type = this_seq_type
     )
@@ -4035,8 +4035,7 @@ fancy_cnbar = function(this_sample_id,
   #get maf data for a specific sample.
   if(missing(seq_data) && is.null(seq_path)){
     seq = get_sample_cn_segments(
-      this_sample_id = this_sample_id,
-      multiple_samples = FALSE,
+      these_sample_ids = this_sample_id,
       streamlined = FALSE,
       from_flatfile = TRUE,
       this_seq_type = this_seq_type
@@ -4393,8 +4392,7 @@ fancy_ideogram = function(this_sample_id,
   #get maf data for a specific sample.
   if(missing(seq_data) && is.null(seq_path)){
     cn_states = get_sample_cn_segments(
-      this_sample_id = this_sample_id,
-      multiple_samples = FALSE,
+      these_sample_ids = this_sample_id,
       with_chr_prefix = FALSE,
       streamlined = FALSE,
       this_seq_type = this_seq_type
@@ -4727,8 +4725,7 @@ fancy_multisamp_ideogram = function(these_sample_ids,
   }else{
     #load CN data
     cn_states = get_sample_cn_segments(
-      multiple_samples = TRUE,
-      sample_list = these_sample_ids,
+      these_sample_ids = these_sample_ids,
       streamlined = FALSE,
       this_seq_type = this_seq_type
     )
@@ -4981,8 +4978,7 @@ comp_report = function(this_sample_id,
 
   if(missing(seq_data) && is.null(seq_path)){
     seq = get_sample_cn_segments(
-      this_sample_id = this_sample_id,
-      multiple_samples = FALSE,
+      these_sample_ids = this_sample_id,
       streamlined = FALSE,
       from_flatfile = TRUE,
       this_seq_type = this_seq_type

--- a/get_gambl_results.smk
+++ b/get_gambl_results.smk
@@ -35,6 +35,7 @@ wildcards = config["default"]["results_merged_wildcards"]
 
 expression = merged["tidy_expression_path"]
 collated = merged["collated"]
+manta = merged["manta_sv"]["icgc_dart"]
 
 #here we specify which files are included from the GAMBLR config
 db_maf = flatfiles["ssm"]["template"]["cds"]["deblacklisted"]
@@ -61,9 +62,18 @@ rule all:
         expression = expression,
         collated = expand(collated,seq_type_filter=['genome','capture']),
         indexed_maf = expand(full_db_maf,seq_type=['genome','capture'],projection=projections),
-        indexed_aug_maf = expand(full_aug_maf,seq_type=['genome','capture'],projection=projections)
+        indexed_aug_maf = expand(full_aug_maf,seq_type=['genome','capture'],projection=projections),
+        manta_sv = expand(manta,projection=projections)
 
 #Use the relative directory for local file names (outputs) and full path for remote file names (inputs)
+
+rule get_manta_sv:
+	input:
+		manta_bedpe = SFTP.remote(hostname + project_base + manta)
+	output:
+		manta_bedpe = manta
+	run:
+		shell("cp {input.manta_bedpe} {output.manta_bedpe}")
 
 rule get_collated:
     input:

--- a/man/adjust_ploidy.Rd
+++ b/man/adjust_ploidy.Rd
@@ -42,15 +42,15 @@ multi-sample seg file. The telomeres are always excluded from calculation, and s
 The chromosome prefix is handled internally per projection and does not need to be consistent.
 }
 \examples{
-sample_seg = get_sample_cn_segments(this_sample_id = "14-36022T")
+sample_seg = get_sample_cn_segments(these_sample_ids = "14-36022T")
 sample_seg = dplyr::rename(sample_seg, "sample" = "ID")
 
 adjust_ploidy(this_seg = sample_seg)
 
-one_sample = get_sample_cn_segments(this_sample_id = "14-36022T")
+one_sample = get_sample_cn_segments(these_sample_ids = "14-36022T")
 one_sample = dplyr::rename(one_sample, "sample" = "ID")
 
-another_sample = get_sample_cn_segments(this_sample_id = "BLGSP-71-21-00243-01A-11E")
+another_sample = get_sample_cn_segments(these_sample_ids = "BLGSP-71-21-00243-01A-11E")
 another_sample = dplyr::rename(another_sample, "sample" = "ID")
 
 multi_sample_seg = rbind(one_sample, another_sample)

--- a/man/annotate_recurrent_cnv.Rd
+++ b/man/annotate_recurrent_cnv.Rd
@@ -22,7 +22,7 @@ This function takes a data frame with CNVs (\code{seq_df}) and annotates recurre
 }
 \examples{
 \dontrun{
-my_segs = get_sample_cn_segments(this_sample_id = "HTMCP-01-06-00422-01A-01D")
+my_segs = get_sample_cn_segments(these_sample_ids = "HTMCP-01-06-00422-01A-01D")
 annotated = annotate_recurrent_cnv(seg_df = my_segs)
 }
 

--- a/man/calculate_pga.Rd
+++ b/man/calculate_pga.Rd
@@ -40,7 +40,7 @@ sample, chrom, start, end, and log.ratio. The function can work with either indi
 excluded from calculation, and centromeres/sex chromosomes can be optionally included or excluded.
 }
 \examples{
-sample_seg = get_sample_cn_segments(this_sample_id = "14-36022T")
+sample_seg = get_sample_cn_segments(these_sample_ids = "14-36022T")
 sample_seg = dplyr::rename(sample_seg, "sample" = "ID")
 
 calculate_pga(this_seg = sample_seg)
@@ -48,10 +48,10 @@ calculate_pga(this_seg = sample_seg)
 calculate_pga(this_seg = sample_seg,
               exclude_sex = FALSE)
 
-one_sample = get_sample_cn_segments(this_sample_id = "14-36022T")
+one_sample = get_sample_cn_segments(these_sample_ids = "14-36022T")
 one_sample = dplyr::rename(one_sample, "sample" = "ID")
 
-another_sample = get_sample_cn_segments(this_sample_id = "BLGSP-71-21-00243-01A-11E")
+another_sample = get_sample_cn_segments(these_sample_ids = "BLGSP-71-21-00243-01A-11E")
 another_sample = dplyr::rename(another_sample, "sample" = "ID")
 
 multi_sample_seg = rbind(one_sample, another_sample)

--- a/man/get_sample_cn_segments.Rd
+++ b/man/get_sample_cn_segments.Rd
@@ -5,9 +5,8 @@
 \title{Get Sample CN Segments.}
 \usage{
 get_sample_cn_segments(
-  this_sample_id,
-  multiple_samples = FALSE,
-  sample_list,
+  these_sample_ids,
+  these_samples_metadata,
   from_flatfile = TRUE,
   projection = "grch37",
   this_seq_type = "genome",
@@ -16,11 +15,9 @@ get_sample_cn_segments(
 )
 }
 \arguments{
-\item{this_sample_id}{Optional argument, single sample_id for the sample to retrieve segments for.}
+\item{these_sample_ids}{Optional argument, sample_id (vector of characters) for the sample(s) to retrieve segments for. If not provided, the function will return CN segments for all available sample IDs present in the current metadata.}
 
-\item{multiple_samples}{Set to TRUE to return cn segments for multiple samples specified in \code{samples_list} parameter. Default is FALSE.}
-
-\item{sample_list}{Optional vector of type character with one sample per row, required if multiple_samples is set to TRUE.}
+\item{these_samples_metadata}{Optional, provide a metadata (data frame) subset to the sample IDs of interest.}
 
 \item{from_flatfile}{Set to TRUE by default.}
 
@@ -40,24 +37,36 @@ Get all segments for a single (or multiple) sample_id(s).
 }
 \details{
 This function returns CN segments for samples. This works for single sample or multiple samples.
-For multiple samples, remember to set the Boolean parameter \code{multiple_samples = TRUE} and give the \code{sample_lsit} a vector of characters with one sample ID per row.
-For more information on how this function can be run in different ways, refer to the parameter descriptions, examples and vignettes.
+Specify the sample IDs you are interested in with \code{these_sample_ids} (as a vector of characters),
+Or call this function with \code{these_samples_metadata} if you already ahve a metadata table subset to the sample IDs of interest.
+If none off the above parameters are specified, the function will return CN segments for available samples.
+Note, this. function internally calls \link{id_ease} for dealing with sample IDs and metadata tables.
 Is this function not what you are looking for? Try one of the following, similar, functions; \link{assign_cn_to_ssm}, \link{get_cn_segments}, \link{get_cn_states},
 }
 \examples{
-# Return cn segments for multiple samples (read csv with one sample per line):
-sample_list = readLines("../samples-test.csv")
-multiple_samples = get_sample_cn_segments(multiple_samples = TRUE, sample_list = sample_list)
-#Return cn segments for multiple samples (provided as vector of sample IDs):
-these_sample_list = c("00-15201_tumorA", "00-15201_tumorB")
+#return everything (default: genome, grch37)
+all_segs = get_sample_cn_segments()
 
-samples = get_sample_cn_segments(multiple_samples = TRUE,
-                                 sample_list = these_sample_list)
-# For capture
-samples = get_sample_cn_segments(
- multiple_samples = TRUE,
- sample_list = these_sample_list,
- this_seq_type = "capture"
-)
+#using sample ID parameter
+one_sample = get_sample_cn_segments(these_sample_ids = "00-22011_tumorB", 
+                                    this_seq_type = "capture")
+
+two_samples = get_sample_cn_segments(these_sample_ids = c("00-14595_tumorA",
+                                                          "00-16220_tumorB"), 
+                                     projection = "hg38")
+
+#get some metadata
+this_meta = get_gambl_metadata() \%>\% 
+ dplyr::filter(sample_id \%in\% c("BLGSP-71-23-00440-01A-01E", 
+                                "FL1014T2",
+                                "HTMCP-01-06-00563-01A-01D"))
+
+capture_meta = get_gambl_metadata(seq_type_filter = "capture")
+
+#return sample segments by using the metadata parameter
+segs_meta = get_sample_cn_segments(these_samples_metadata = this_meta)
+
+all_segs_cap = get_sample_cn_segments(these_samples_metadata = capture_meta, 
+                                      projection = "hg38")
 
 }

--- a/vignettes/cn_sv_tutorial.Rmd
+++ b/vignettes/cn_sv_tutorial.Rmd
@@ -7,11 +7,10 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 ```{r setup, include = FALSE}
-knitr::opts_chunk$set(warning = FALSE, message = FALSE)
-options(bitmapType='cairo')
+knitr::opts_chunk$set(warning = FALSE, message = FALSE, fig.width = 7, fig.height = 5, fig.align = "center")
 ```
 
-```{r load_packages, message = FALSE, warning = FALSE, echo = FALSE, results = 'hide'}
+```{r load_packages, message = FALSE, warning = FALSE, echo = FALSE}
 library(GAMBLR)
 library(tidyverse)
 library(rmarkdown)
@@ -27,7 +26,7 @@ This vignette demonstrates how to return Copy Number (CN) and Structural Variant
 
 ## Let's get started
 A good way to start is to retrieve metadata for all GAMBL samples. In this tutorial, we are only interested in samples with seq type **genome**. To get metadata for all such samples, we call `get_gambl_metadata`. Let us also subset the main metadata based on a few criteria.
-```{r get_gambl_metadata, message = FALSE, warning = FALSE}
+```{r get_gambl_metadata}
 #get metadata for all samples
 all_metadata = get_gambl_metadata(seq_type_filter = "genome")
 
@@ -39,7 +38,7 @@ dlbcl_fl_metadata = dplyr::filter(all_metadata, pathology %in% c("DLBCL", "FL"))
 ```
 
 While we are at it, let us also define a few variables that we will use in the subsequent steps.
-```{r set_variables, message = FALSE, warning = FALSE}
+```{r set_variables}
 #define a sample
 this_sample_id = "HTMCP-01-06-00422-01A-01D"
 these_sample_list = c("00-15201_tumorA", "00-15201_tumorB")
@@ -61,7 +60,7 @@ some_lymphoma_genes = c("TNFRSF14","NOL9","KLHL21",
 ## CN
 ### CN Segments
 If we are interested in CN segments in specific genomic regions, the recommended approach is to call `get_cn_segments`. This function takes a variety of parameters that will allow the user to easily define what regions they are interested in. For example, if this function is being called using the `region` parameter, the function expects a region defined in the following format; **"chr:start-end"**. It is also possible to individually specify these coordinates with `chr`, `qstart` and `qend`. Another parameter to be aware of is `streamlined`, similarly to other GAMBLR function, this parameter controls the number of columns present in the returned data frame. If set to `FALSE`, full MAF-like format is returned and with this parameter set to `TRUE` only basic columns are kept. In addition, the parameter `remove_chr_prefix` is available for dealing with chr prefixes of the returned data frame. In the following example we are demonstrating how to use these different parameters in various combinations.
-```{r get_cn_segments, message = FALSE, warning = FALSE}
+```{r get_cn_segments}
 #using the region parameter
 my_segments_grch37 = get_cn_segments(region = "chr8:128,723,128-128,774,067", 
                                      projection = "grch37", 
@@ -90,7 +89,7 @@ myc_cns = get_cn_segments(region = myc_region,
 
 ### CN States
 If you are interested in returning the copy number states for a specific region, one can call *get_cn_states*. This function takes a region (or regions) in the centralized region-format (chr:start-end) as well as region names (e.g gene symbols) to subset the returned cn states on. The function returns a data frame with absolute copy number states for the queried regions. In this example, we are returning copy number states for MYC (previously defined region) across all available samples. We are then filtering out all samples that show the expected copy number state (i.e 2) and are visualizing the counts of each copy number state for the remaining samples.
-```{r get_cn_states, message = FALSE, warning = FALSE}
+```{r get_cn_states}
 #get cn states for a specific region
 single_gene_cn = get_cn_states(regions_list = myc_region,
                                region_names = "MYC")
@@ -115,21 +114,20 @@ ggplot(myc_cn_mutated, aes(x = cn_state)) +
 ### Sample CN Segments
 If you are interested in returning all CN segments for one sample (or multiple samples), `get_sample_cn_segments` is available for this purpose. This functions takes an optional parameter called `this_sample_id` for query of a singular sample. If CN segments for multiple samples are to be returned, first toggle the Boolean parameter `multiple_samples` to TRUE and provide a list of sample IDs in the `samples_list` parameter. Other convenient parameters are `with_chr_prefis`, if set to **TRUE**, chromosome prefixes (chr) will be added to the returned data frame. For returning minimal output (rather than full details)m, set `streamlined` to **TRUE**. In this example we will first call the described function with default parameters for one sample, the next example we will demonstrate the multiple-samples-return functionality. 
 
-```{r get_sample_cn_segments, message = FALSE, warning = FALSE}
+```{r get_sample_cn_segments}
 #get cn segments for one sample.
-one_sample_cn_segs = get_sample_cn_segments(this_sample_id = this_sample_id)
+one_sample_cn_segs = get_sample_cn_segments(these_sample_ids = this_sample_id)
 
 #return chr-prefixed cn segments for multiple samples.
-multiple_samples_cn_seqs = get_sample_cn_segments(multiple_samples = TRUE, 
-                                                  sample_list = these_sample_list,
+multiple_samples_cn_seqs = get_sample_cn_segments(these_sample_ids = these_sample_list,
                                                   projection = "hg38", 
                                                   with_chr_prefix = TRUE)
 ```
 
 ### Assign CN to SSM
 For annotating mutations with CN information, we have `assign_cn_to_ssm` available. This function provides great flexibility for annotating mutations from a variety of sources. For example, the user can either provide an already loaded MAF with mutations to be annotated with the parameter `maf_df` or a path to a local MAF file with `maf_file`. If neither of these parameters are used, the function will run `get_ssm_by_sample` with a sample ID specified in `this_sample` to return sample-specific SSMs.Similarly, one can also use a local file path for associated CN segments. This is achieved with calling the function with the `seg_file` parameter. This function also has a variety of convenience parameters for improved flexibility. For example, the return can be subset to specific genes with `genes` parameter. We can also restrict the return to only show coding mutations (`coding_only = TRUE`). In addition, include silent mutations can also be toggled with the parameter `include_silent` (Boolean). The returned data frame shares the same columns as your standard MAF but with two extra columns (**CN** and **log.ratio**). In this example we will call this function with a selection of different parameters to thoroughly demonstrate each different scenario (parameter combinations).
-```{r assign_cn_to_ssm, message = FALSE, warning = FALSE}
-#annotate a MAF wigh compy number information.
+```{r assign_cn_to_ssm}
+#annotate a MAF with copy number information.
 annotated_ssm = assign_cn_to_ssm(this_sample_id = this_sample_id)
 
 #use same sample for annotating SSM with CN restricted to a specific set of genes.
@@ -147,8 +145,8 @@ annotated_ssm_extended = assign_cn_to_ssm(this_sample_id = this_sample_id,
 
 ## SV
 ### Combined SVs
-IF you want to retrieve combined SV calls (manta and GRIDSS-derived) for one or more samples, you should look into `get_combined_sv`. This function does exactly this. Similarly to other GAMBLR function, we have a collection of familiar parameters available. The required parameters are `sample_ids`, a character vector of tumour sample IDs you wish to retrieve SVs for. Another useful way to subset your returned SVs based on VAF score is with the `min_vaf` parameter, this parameter hgolds the minimum tumour VAF for a SV to be returned. Recommended: 0. (default: 0). The bedpe files used as input to this function were pre-filtered for a minimum VAF of 0.05, and SVs affecting common translocation regions (BCL2, BCL6, MYC, CCND1) were whitelisted (e.g. no VAF filter applied). Therefore if you wish to post-filter the SVs we recommend doing so carefully after loading this data frame. Further, the input bedpe file is annotated with oncogenes and superenhancers from naive and germinal centre B-cells. You can subset to events affecting certain loci using the `oncogenes` argument.
-```{r get_combined_sv, message = FALSE, warning = FALSE}
+IF you want to retrieve combined SV calls (manta and GRIDSS-derived) for one or more samples, you should look into `get_combined_sv`. This function does exactly this. Similarly to other GAMBLR function, we have a collection of familiar parameters available. The required parameters are `sample_ids`, a character vector of tumour sample IDs you wish to retrieve SVs for. Another useful way to subset your returned SVs based on VAF score is with the `min_vaf` parameter, this parameter holds the minimum tumour VAF for a SV to be returned. Recommended: 0. (default: 0). The bedpe files used as input to this function were pre-filtered for a minimum VAF of 0.05, and SVs affecting common translocation regions (BCL2, BCL6, MYC, CCND1) were whitelisted (e.g. no VAF filter applied). Therefore if you wish to post-filter the SVs we recommend doing so carefully after loading this data frame. Further, the input bedpe file is annotated with oncogenes and superenhancers from naive and germinal center B-cells. You can subset to events affecting certain loci using the `oncogenes` argument.
+```{r get_combined_sv}
 #example with minimal parameter usage.
 combined_svs = get_combined_sv(these_sample_ids = this_sample_id)
 
@@ -160,14 +158,14 @@ combined_sv_extended = get_combined_sv(these_sample_ids = these_sample_list,
 
 ### Manta SVs
 If you are interested in just retrieving manta SV call this is of course also possible. With `get_manta_sv` you can retrieve SVs from this specific call-set and filter with available function parameters. To call this function with the minimum parameters, no parameters are required. If the function is called in this way, all SVs are returned with default filtering parameters. If you have a sample ID you are interested in, you simply call this function with the `sample_id` parameter. Let's go over the filtering options available for this function. Similarly to `get_combined_sv`, the following parameters are also available for this function; `min_vaf`, and `from_flatfile`. In addition, we also have; `min_score` describing the lowest Manta somatic score for a SV to be returned. `pass`, If set to TRUE, include SVs that are annotated with PASS in FILTER column. `pair_status` To restrict results (if desired) to matched or unmatched results (default is to return all). `chromosome` The chromosome you are restricting to. `qstart` Query start coordinate of the range you are restricting to. `qend` Query end coordinate of the range you are restricting to. `region` Formatted like chrX:1234-5678 instead of specifying chromosome, start and end separately. In the following example, we will look at a few different examples exploring some of the different parameters. 
-```{r get_manta_sv, message = FALSE, warning = FALSE}
+```{r get_manta_sv}
 #get all SVs.
 all_svs = get_manta_sv()
 
 #peek dimensions of returned SV calls
 dim(all_svs)
 
-#extended example, return all SVs with a minimum vaf score of 0.1, minimum manta somatic score of 40, for MYC region, with chromosome prefixes. 
+#extended example, return all SVs with a minimum vaf score of 0.1, minimum manta somatic score of 40, for MYC region. 
 manta_svs = get_manta_sv(min_vaf = 0.1, 
                          min_score = 40, 
                          pass = TRUE, 
@@ -185,7 +183,7 @@ If you want to convert your SV calls into a UCSC-ready custom track, for interro
 ## Visualization
 ### Variant Counts
 Interested in how many variants are present in a given sample? A quick way to overview such information would be to call `fancy_svbar` on a given sample ID. This function returns a bar plot visualizing SVs or SSMs. A variety of sub-setting options are also available. Such as chromosome selection and variant types to be included in plot.
-```{r svbar, dpi = 150}
+```{r svbar}
 #build plot
 fancy_v_count(this_sample_id = this_sample_id,
               ssm = FALSE,
@@ -196,7 +194,7 @@ fancy_v_count(this_sample_id = this_sample_id,
 
 ### Variant Counts Per Chromosome.
 Sometimes it can be useful to overview variant distributions across the complete genomic landscape. To do so, one could call `fancy_v_chrcount` with sample ID. Optional arguments for sub-setting your data are available (see parameter descriptions for more information). In the following example we are plotting SV (ssm = FALSE) counts for autosomes. One can also call `add_qc_metric` to add a second y-axis annotating mean corrected coverage for the selected sample.
-```{r svdist, dpi = 150}
+```{r svdist}
 #build plot
 fancy_v_chrcount(this_sample_id = "HTMCP-01-06-00422-01A-01D",
                  plot_subtitle =  "grch37",
@@ -212,7 +210,7 @@ fancy_v_chrcount(this_sample_id = "HTMCP-01-06-00422-01A-01D",
 
 ### Variant Size Densities.
 Another useful plotting function for visualizing SV size distributions is with `fancy_sv_sizedens`. In this example, we are showing SVs (larger 50bp and with a with minimum vaf of 0) size distributions for a specific sample and selected chromosomes.
-```{r sv_size, dpi = 150}
+```{r sv_size}
 #build plot
 fancy_sv_sizedens(this_sample_id = this_sample_id,
                   vaf_cutoff = 0,
@@ -225,7 +223,7 @@ fancy_sv_sizedens(this_sample_id = this_sample_id,
 
 ## Copy Number States Summaries.
 Another way to visualize copy number information is with the the `fancy_cnvbar`. This function takes one required parameter (sample ID), calls `get_cn_segments` and `assign_cn_ssm` to retrieve data for plotting. The plot highlights the number of CN states for any given sample (left y-axis), together with n bases included in each given CN state (right y-axis).
-```{r cnbar, dpi = 150}
+```{r cnbar}
 #build plot
 fancy_cnbar(this_sample_id = this_sample_id,
             plot_title = "CNV Barplot Example",
@@ -236,7 +234,7 @@ fancy_cnbar(this_sample_id = this_sample_id,
 
 ## Copy Number Segments Plot
 Another way to visualize CN segments is with the `focal_cn_plot`. This function visualizes all CN segments for a defined region, colours the returned segments based on lymphgen information. In addition, this function takes either a specified region (chr:start-end format). If no region is supplied, the user can give the function a gene symbol with `gene`. If so, the function will internally retrieve the region for the specified gene.Sample IDs are specified along the y-axis and the genomic postilion iis visualized along the x-axis.
-```{r cnfocal, dpi = 150}
+```{r cnfocal}
 #get metadata
 this_metadata = get_gambl_metadata()
 

--- a/vignettes/fancy_plots.Rmd
+++ b/vignettes/fancy_plots.Rmd
@@ -7,12 +7,11 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 ```{r setup, include = FALSE}
-knitr::opts_chunk$set(warning = FALSE, message = FALSE)
-options(bitmapType='cairo')
+knitr::opts_chunk$set(warning = FALSE, message = FALSE, fig.width = 7, fig.height = 5, fig.align = "center")
 ```
 # Plotting Parameters, Global Variables and Packages.
 Define global plotting parameters, load packages etc.
-```{r load_packages, message = FALSE, warning = FALSE}
+```{r load_packages, message = FALSE, warning = FALSE, echo = FALSE}
 library(GAMBLR)
 library(tidyverse)
 library(rmarkdown)
@@ -34,8 +33,7 @@ maf = assign_cn_to_ssm(this_sample_id = this_sample,
                        use_augmented_maf = TRUE)$maf
 
 #get seq data
-seq = get_sample_cn_segments(this_sample = this_sample,
-                             multiple_samples = FALSE,
+seq = get_sample_cn_segments(these_sample_ids = this_sample,
                              streamlined = FALSE,
                              from_flatfile = TRUE)
 
@@ -71,7 +69,7 @@ This vignette explores newly added plotting functions in GAMBLR, directed toward
 ## Variant Overview
 ### Variant Counts
 Interested in how many variants are present in a given sample? A quick way to overview such information would be to call `fancy_svbar` on a given sample ID. This function returns a bar plot visualizing SVs or SSMs. A variety of sub-setting options are also available. Such as chromosome selection and variant types to be included in plot. In the example bellow, we're looking at genome-wide SSMs for one selected sample.
-```{r svbar, dpi = 150}
+```{r svbar}
 fancy_v_count(this_sample_id = this_sample,
               maf_data = maf,
               ssm = TRUE,
@@ -88,7 +86,7 @@ fancy_v_count(this_sample_id = this_sample,
 
 ### Variant Counts Per Chromosome.
 Sometimes it can be useful to overview variant distributions (SSM or SVs) across the complete genomic landscape. To do so, one could call `fancy_v_chrcount` with sample ID. Optional arguments for sub-setting your data are available (see parameter descriptions for more information). In the following example we're plotting SV (ssm = FALSE) counts for autosomes. One can also call `add_qc_metric` to add a second y-axis annotating mean corrected coverage for the selected sample.
-```{r svdist, dpi = 150}
+```{r svdist}
 fancy_v_chrcount(this_sample_id = "HTMCP-01-06-00422-01A-01D",
                  plot_subtitle =  "grch37",
                  plot_title = "SV Genomic Distribution Example",
@@ -103,7 +101,7 @@ fancy_v_chrcount(this_sample_id = "HTMCP-01-06-00422-01A-01D",
 
 ### Variant Size Distributions
 A useful way to visualize variant size distributions is to call `fancy_v_sizedis` to generate a violin plot showing  variant size distributions (sample-level) across selected contigs (per default chr1-22). Optional parameters to sub-set data to include only coding regions are also available for this function, as well as to plot SVs by setting `ssm = FALSE`.
-```{r svvplot, dpi = 150}
+```{r svvplot}
 fancy_v_sizedis(this_sample_id = this_sample,
                 maf_data = maf,
                 plot_title = "SV (small variants) Size Distribution Example",
@@ -120,7 +118,7 @@ fancy_v_sizedis(this_sample_id = this_sample,
 
 ### Structural Variant Size Densities.
 Another useful plotting function for visualizing SV size distributions is `fancy_sv_sizedens`. In this example, we're showing SVs (larger 50bp and with a with minimum vaf of 0) size distributions for a specific sample and selected chromosomes.
-```{r sv_size, dpi = 150}
+```{r sv_size}
 fancy_sv_sizedens(this_sample_id = this_sample,
                   vaf_cutoff = 0,
                   size_cutoff = 50,
@@ -132,7 +130,7 @@ fancy_sv_sizedens(this_sample_id = this_sample,
 
 ## Single Nucleotide Variants Chromosome Distributions.
 Curious to see how SNVs are distributed across specific chromosomes? For this purpose `fancy_snv_chrdistplot` was developed. This function takes a sample ID and retrieves SNV information (using `assign_cn_to_ssm`) and plots variants in an ideogram dependent manner. Similarly to other `fanxy_x_plot` functions, a selection of parameters are available for data sub-setting and plot customization. For example, by calling the include_dnp, DNP counts will be added to each bar.
-```{r snvbar, dpi = 150}
+```{r snvbar}
 fancy_snv_chrdistplot(this_sample_id = this_sample,
                       maf_data = maf,
                       plot_subtitle = "SNV Distribution Example",
@@ -146,7 +144,7 @@ fancy_snv_chrdistplot(this_sample_id = this_sample,
 
 ## Copy Number States Summaries.
 A useful way to visualize copy number information is with the the `fancy_cnvbar`. This function takes one required parameter (sample ID), calls `get_cn_segments` and `assign_cn_ssm` to retrieve data for plotting. The plot highlights the number of CN states for any given sample (left y-axis), together with n bases included in each given CN state (right y-axis).
-```{r cnbar, dpi = 150}
+```{r cnbar}
 fancy_cnbar(this_sample_id = this_sample,
             seq_data = seq,
             plot_title = "CNV Barplot Example",
@@ -160,7 +158,7 @@ This section explores ideogram plotting functions available withing GAMBLR. Func
 
 ## Sample-level Ideograms.
 A great way to overview SVs and Copy Number Segments on sample-level is to call `fancy_ideogram`. This function creates an ideogram based on the chromosomes defined in the `chr_select` parameter. Copy Number states are plotted along the x-axis (selected contigs plotted vertically on the y-axis). The plot annotates Copy Number States from 0 to 6+. Additional support for superimposing SVs on the ideogram is also possible, by setting `include_sv` to TRUE, deletions and insertions will be plotted as lollipops. n Number of SVs can also be added for each contig. This is achieved by specifying `sv_count` to TRUE. In addition, it's also possible to highlight genomic regions fo interest, such as genes, hotspots, difficult to map regions, etc. For convenience, one can specify a list of genes under the `gene_annotation` parameter. The function will then implement `gene_to_region` function to convert gene names to bed-style coordinates.
-```{r fancy_ideogram, dpi = 150, fig.height = 14, fig.width = 14}
+```{r fancy_ideogram, fig.height = 14, fig.width = 14}
 fancy_ideogram(this_sample_id = this_sample,
                gene_annotation = "MYC",
                plot_title = "Sample-level Ideogram Example",
@@ -169,7 +167,7 @@ fancy_ideogram(this_sample_id = this_sample,
 
 ## Multi-sample Ideograms
 It's also possible to plot multiple samples (2, 3 or 4) in a similar manner. This can be used to infer inheritance patterns, hotspots, etc. across multiple samples. For this purpose `fancy_ideogram_multisamp` was developed. This function is called with similar parameters as `fancy_ideogram` with the addition that `this_sample` has been replaced with `these_sample_ids`. The function automatically detects the number of samples provided and sets the plotting parameters accordingly.
-```{r fancy_ideogram_multisamp, dpi = 150, fig.height = 14, fig.width = 14}
+```{r fancy_ideogram_multisamp, fig.height = 14, fig.width = 14}
 #load two samples
 two_samples = c("00-15201_tumorA", "00-15201_tumorB")
 
@@ -187,7 +185,7 @@ This section explores different ways to visualize QC metrics. All functions in t
 
 ## Alignment Metrics Summaries.
 This function takes a list of sample IDs and gathers relevant metrics (alignment) to be plotted. Alternatively, if no df with sample IDs is provided, the function internally calls `get_gambl_metadata` to get sample IDs. The function also has convenience parameters allowing for easy subset to a specific pathology/cohort. In addition, the function also takes a df with comparison samples (sample IDs) allowing for an easy and straight-forward comparison between selected samples vs any other subset of samples. In this example, we are plotting alignment metrics for all FL samples in the scope of all BL cases.
-```{r fancy_alignment_plot, dpi = 150, fig.height = 8, fig.width = 18}
+```{r fancy_alignment_plot, fig.height = 8, fig.width = 18}
 #build plot
 fancy_alignment_plot(these_sample_ids = sub_fl,
                      comparison_group = all_bl,
@@ -198,7 +196,7 @@ fancy_alignment_plot(these_sample_ids = sub_fl,
 
 ## Flexible Quality Control Metric Plots.
 If you are interested in exploring the distribution of a specific QC metric for a set number of sample IDs, `fancy_qc_plot` is the way to go. This function lets the user specify what metric they want to plot across different sample subsets, flexible comparison group options, as well as grouping the plot by a factor of choice. Unsure what metrics are available for plotting? Just call the function with `return_plotdata = TRUE` and a list of available metrics will be returned (and nothing else). In this example we are looking at Average Base Quality for FL samples in the "Kridel" cohort, compared to BL samples in the BL pediatric cohort. Each bar in the shown plot represent an individual sample from the defined pathology/cohort, dotted hline is annotating the mean value for selected sample and the solid hline is describing the mean value for the selected comparison group.
-```{r fancy_qc_plot, dpi = 150}
+```{r fancy_qc_plot}
 #return available metrics for plotting
 fancy_qc_plot(return_plotdata = TRUE)
 
@@ -219,7 +217,7 @@ fancy_qc_plot(keep_pathology = "FL", #pathology filtering criteria for samples t
 
 ## Coverage Summary Plots.
 Curious to see what fractions of a specific subset of samples have at least 10X and 30X coverage? For this purpose `fancy_propcov_plot` was developed. This function outputs a violin plot annotating the percentages of selected samples that have at least 10X and 30X coverage. The plot also allows for a straightforward comparison with another subset of samples. This allows the user to quickly interrogate how the coverage of a set number of samples (from different cohort/pathology) compares to another group of samples. In this example, we're once again looking at how the coverage compares for all FL cases vs all gambl samples.
-```{r  fancy_propcov_plot, dpi = 150}
+```{r  fancy_propcov_plot}
 #build plot
 fancy_propcov_plot(these_sample_ids = sub_fl,
                    comparison_samples = all_samples,
@@ -229,7 +227,7 @@ fancy_propcov_plot(these_sample_ids = sub_fl,
 
 ## Proportional Metrics.
 Another way to inspect proportional QC metrics is by calling `fancy_proportions_plot`. This function gathers all proportional QC metrics and plots them in a grouped bar plot (similarly to `fancy_alignment_plot`). These metrics include `duplicated reads`, `mapped reads`, `=>10X coverage reads`, and `=>30X coverage reads`. In this example we are looking at FL samples from the Kridel cohort. This function also annotates the mean values for the plotted metrics.
-```{r fancy_proportions_plot, dpi = 150, fig.height = 8, fig.width = 18}
+```{r fancy_proportions_plot}
 kridel_fl = get_gambl_metadata() %>%
   dplyr::filter(pathology == "FL", cohort == "FL_Kridel") %>%
   dplyr::select(sample_id)

--- a/vignettes/ssm_tutorial.Rmd
+++ b/vignettes/ssm_tutorial.Rmd
@@ -7,10 +7,10 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 ```{r setup, include = FALSE}
-knitr::opts_chunk$set(warning = FALSE, message = FALSE)
+knitr::opts_chunk$set(warning = FALSE, message = FALSE, fig.width = 7, fig.height = 5, fig.align = "center")
 ```
 
-```{r load_packages, message = FALSE, warning = FALSE, echo = FALSE, results = 'hide'}
+```{r load_packages, message = FALSE, warning = FALSE, echo = FALSE}
 library(GAMBLR)
 library(GAMBLR.data)
 library(tidyverse)
@@ -28,7 +28,7 @@ This vignette demonstrates how to work with Simple Somatic Mutations (SSM) resul
 
 ## Metadata
 First, lets start with retrieving metadata for all GAMBL samples with `seqtype` *genome*.
-```{r metadata, message = FALSE, warning = FALSE}
+```{r metadata}
 #get gambl metadata for all samples
 this_metadata = get_gambl_metadata(seq_type_filter = "genome")
 
@@ -42,7 +42,7 @@ Based on the information available to the user, application, or downstream analy
 
 ### By Sample
 Return SSMs for one specific sample with `get_ssm_by_sample`. In the example bellow, the augmented MAF is loaded (grch37, slims-3 and clustered) and variants with a minimum read support of 3 are kept. Basic column is set to *TRUE*, this means the function will only return the standard 45 columns out of all 116 columns present in the original MAF. In addition, the parameter `these_genes` is available for easy subset of variants to specific genomic loci.
-```{r get_ssm_by_sample, message = FALSE, warning = FALSE}
+```{r get_ssm_by_sample}
 #set sample ID
 this_sample = "00-15201_tumorA"
 
@@ -53,7 +53,7 @@ this_sample_ssm = get_ssm_by_sample(this_sample_id = this_sample,
 ```
 
 To return SSMs for multiple samples one can use `get_ssm_by_samples`. Note, this function wraps `get_ssm_by_sample`.
-```{r get_ssm_by_samples, message = FALSE, warning = FALSE}
+```{r get_ssm_by_samples}
 #set sample IDs
 these_samples = c("HTMCP-01-06-00485-01A-01D", 
                   "14-35472_tumorA", 
@@ -67,7 +67,7 @@ these_samples_ssm = get_ssm_by_samples(these_sample_ids = these_samples,
 
 ### By Patient
 Return SSMs for a set of patients with `get_ssm_by_patients`.
-```{r get_ssm_by_patients, message = FALSE, warning = FALSE}
+```{r get_ssm_by_patients}
 #set patient IDs
 these_patients = c("00-14595", 
                    "00-15201", 
@@ -81,7 +81,7 @@ these_patients_ssm = get_ssm_by_patients(these_patient_ids = these_patients,
 
 ### By Region
 Return SSMs based on a specific region with `get_ssm_by_region`. In this example we are using `gene_to_region` to get genomic coordinates for a specific gene that will be called by `get_ssm_by_region`.
-```{r get_ssm_by_region, message = FALSE, warning = FALSE}
+```{r get_ssm_by_region}
 #get region
 myc_region = gene_to_region(gene_symbol = "MYC", 
                             return_as = "region")
@@ -93,7 +93,7 @@ myc_ssm = get_ssm_by_region(region = myc_region,
 ```
 
 For multiple regions, refer to `get_ssm_by_regions`. In this example we are returning SSMs for all ASHM regions (hyper mutated) across all samples. 
-```{r get_sm_by_regions, message = FALSE, warning = FALSE}
+```{r get_sm_by_regions}
 #convert regions to bed format
 my_bed = gene_to_region(gene_symbol = c("MYC", "CD58"), return_as = "bed")
 
@@ -105,7 +105,7 @@ bed_ssm = get_ssm_by_regions(regions_bed = my_bed,
 
 ### Coding SSM
 Lastly, another way to retrieve SSMs is to call `get_coding_ssm`. This function returns coding SSMs for any given sample. This function is a convenient option for anyone interested in plotting coding mutations. Convenient filtering parameters are included in this function for easy and straight-forward subset to specific pathologist, cohorts, and sample IDs. If these parameters are not called, coding SSMs will be returned for all samples. In the example bellow, we are using a metadata subset (DLBCL cases) for retrieving coding ssm.
-```{r get_coding_ssm, message = FALSE, warning = FALSE}
+```{r get_coding_ssm}
 #create metadata subset
 my_sample_metadata = get_gambl_metadata(seq_type_filter = "genome") %>%
   dplyr::filter(pathology == "DLBCL")
@@ -130,7 +130,7 @@ deblacklisted_ssm = annotate_ssm_blacklist(mutations_df = all_coding_ssm,
 
 ### Drivers
 Another useful way to annotate SSMs is with `annotate_driver_ssm`. This function indicates what rows (mutations) are putative driver mutations. For this example, we are annotating the single-sample MAF file that got returned with `get_ssm_by_sample`. This function can also take additional optional parameters to restrict the annotations to specific lymphoma types and known driver genes.
-```{r annotate_driver_ssm, message = FALSE, warning = FALSE}
+```{r annotate_driver_ssm}
 #annotate sample-level maf with putative driver mutations
 driver_ssm = annotate_driver_ssm(maf_df = this_sample_ssm, 
                                  lymphoma_type = c("DLBCL"))
@@ -138,7 +138,7 @@ driver_ssm = annotate_driver_ssm(maf_df = this_sample_ssm,
 
 ### Hotspots
 Another way to annotate an incoming MAF with SSMs is to call `annotate_hotspots`. This function annotates MAF-like data frame with a *hot_spot* column indicating recurrent mutations. The function takes the following parameters; `mutation_maf` - which is expecting a data frame in MAF-like format, `recurrence_min` - minimum number of recurrences for mutation to be included (default is 5), `analysis_base` - base name for hot spot output directory and `p_thresh` - P value threshold, default is 0.05. In this example, we are querying the MAF that was returned from the one-sample (`get_ssm_by_sample`). 
-```{r annotate_hotspots, message = FALSE, warning = FALSE}
+```{r annotate_hotspots}
 #annotate mutational hotspots
 this_sample_ssm_hot = annotate_hotspots(mutation_maf = this_sample_ssm, 
                                         recurrence_min = 5,
@@ -148,7 +148,7 @@ this_sample_ssm_hot = annotate_hotspots(mutation_maf = this_sample_ssm,
 
 ### Review Hotspots
 Returned hotspots can also be further reviewed with `review_hotspots`. This function expects an MAF that has already been annotated with `annotate_hotspots`.
-```{r review_hotspots, message = FALSE, warning = FALSE}
+```{r review_hotspots}
 #review hotspots
 this_sample_ssm_hot_rev = review_hotspots(annotated_maf = this_sample_ssm_hot, 
                                           genes_of_interest = "MYD88", 
@@ -157,7 +157,7 @@ this_sample_ssm_hot_rev = review_hotspots(annotated_maf = this_sample_ssm_hot,
 
 ### Custom Track (UCSC)
 Lastly, we can also transform the annotated MAF into a  custom track file for visualization on th UCSC genome browser. This can be achieved with the function `maf_to_custum_track`. 
-```{r maf_to_custom_track, message = FALSE, warning = FALSE}
+```{r maf_to_custom_track}
 #transform the annotated maf into a custom track for UCSC genome browser interrogation
 ucsc_customtrack = maf_to_custom_track(maf_data = this_sample_ssm_hot_rev,
                                        as_bigbed = FALSE,
@@ -170,7 +170,7 @@ ucsc_customtrack = maf_to_custom_track(maf_data = this_sample_ssm_hot_rev,
 ## SSM Visualization
 ### Variant Counts
 Interested in how many variants are present in a given sample? A quick way to overview such information would be to call `fancy_svbar` on a given sample ID. This function returns a bar plot visualizing SVs or SSMs. A variety of sub-setting options are also available. Such as chromosome selection and variant types to be included in plot. In the example bellow, we are looking at genome-wide SSMs for one selected sample.
-```{r fancy_v_count, dpi = 150, message = FALSE, warning = FALSE}
+```{r fancy_v_count}
 #get ssm data for one sample
 this_sample_ssm = get_ssm_by_sample(this_sample_id = "HTMCP-01-06-00422-01A-01D", 
                                     this_seq_type = "genome",
@@ -191,7 +191,7 @@ fancy_v_count(maf_data = this_sample_ssm,
 
 ### Variant Counts Per Chromosome.
 Sometimes it can be useful to overview variant distributions across the complete genomic landscape. To do so, one could call `fancy_v_chrcount` with sample ID. Optional arguments for sub-setting your data are available (see parameter descriptions for more information). In the following example we're plotting SSM counts for all autosomes. One can also call `add_qc_metric` to add a second y-axis annotating mean corrected coverage for the selected sample.
-```{r fancy_v_chrcount, dpi = 150, message = FALSE, warning = FALSE}
+```{r fancy_v_chrcount}
 fancy_v_chrcount(maf_data = this_sample_ssm,  
                  plot_subtitle =  "grch37",
                  plot_title = "Fig 2.",
@@ -205,7 +205,7 @@ fancy_v_chrcount(maf_data = this_sample_ssm,
 
 ### Variant Size Distributions
 A useful way to visualize variant size distributions is to call `fancy_v_sizedis` to generate a violin plot showing  variant size distributions (sample-level) across selected contigs (per default chr1-22). Optional parameters to sub-set data to include only coding regions are also available for this function, as well as to plot SVs by setting `ssm = FALSE`.
-```{r fancy_v_sizedis, dpi = 150, message = FALSE, warning = FALSE}
+```{r fancy_v_sizedis}
 fancy_v_sizedis(maf_data = this_sample_ssm,
                 ssm = TRUE,
                 plot_trim = FALSE,
@@ -218,7 +218,7 @@ fancy_v_sizedis(maf_data = this_sample_ssm,
 
 ### Single Nucleotide Variants Chromosome Distributions
 Curious to see how SNVs are distributed across specific chromosomes? For this purpose `fancy_snv_chrdistplot` was developed. This function takes a sample ID and retrieves SNV information (using `assign_cn_to_ssm`) and plots variants in an ideogram dependent manner. Similarly to other `fanxy_x_plot` functions, a selection of parameters are available for data sub-setting and plot customization. For example, by calling the include_dnp, DNP counts will be added to each bar.
-```{r fancy_snv_chrdistplot, dpi = 150, message = FALSE, warning = FALSE}
+```{r fancy_snv_chrdistplot}
 fancy_snv_chrdistplot(maf_data = this_sample_ssm,
                       plot_subtitle = "SNV Distribution Example",
                       plot_title = "Fig 4.",
@@ -228,7 +228,7 @@ fancy_snv_chrdistplot(maf_data = this_sample_ssm,
 
 ### Forest Plot
 The `prettyForestPlot` function is used to compare mutation frequencies for a set of genes between two groups. In this example, pathology is set to **FL** and **DLBCL** (the two groups to be compared). Next, to get coding mutations for the selected samples, `get_coding_ssm` is called with `limit_samples` parameter, giving it the sample id column from the recently subset metadata. This function returns two types of plot (box plot and forest plot), the user can either view them separately or arranged on the same grob (showed in this example).
-```{r pretyyForestPlot, dpi = 150, message = FALSE, warning = FALSE}
+```{r pretyyForestPlot}
 metadata_fl_dlbcl = get_gambl_metadata() %>%
   dplyr::filter(pairing_status == "matched") %>%
   dplyr::filter(consensus_pathology %in% c("FL", "DLBCL"))
@@ -250,7 +250,7 @@ forest_plot$arranged
 
 ### Rainbow Plots
 The `ashm_rainbow_plot` allows the user to plot all mutations in a region, ordered and coloured by defined metadata columns. This function also has convenient parameters for highlighting specific regions within the larger defined region. For example, here we are looking at mutations withing MYC, the plot is showing 10K bases upstream and downstream of MYC, with MYC highlighted. Samples are plotted along the y-axis and genomic positions are in respect to the x-axis. On this example, samples are colour-coded based on their pathology status. 
-```{r ashm_rainbow_plot, fig.height = 6, fig.width = 10, dpi = 150, message = FALSE, warning = FALSE}
+```{r ashm_rainbow_plot, fig.height = 6, fig.width = 10, fig.align = "center"}
 #set region for the plot to highlight.
 mybed = data.frame(start = 128747680,
                    end = 128753674,
@@ -278,7 +278,7 @@ ashm_rainbow_plot(mutations_maf = my_mutations,
 ```
 
 If you are in fact interested in plotting multi-panel overview of hypermutations in regions of interest across many samples. You should try out `ashm_multi_rainbow_plot`.
-```{r ashm_multi-rainbow_plot, dpi = 150, fig.height = 6, fig.width = 10, warning = FALSE, message = FALSE}
+```{r ashm_multi-rainbow_plot, fig.height = 6, fig.width = 10, fig.align = "center"}
 #construct a multi-panel ashm rainbow plot
 ashm_multi_rainbow_plot(custom_colours = get_gambl_colours("pathology"),
                         metadata = fl_dlbcl_metadata,
@@ -290,7 +290,7 @@ ashm_multi_rainbow_plot(custom_colours = get_gambl_colours("pathology"),
 
 ### Rainfall Plot
 This plotting function is available for plotting one or multiple samples and takes either an already loaded MAF data frame or a MAF path. If none are supplied the function will get ssm data using one of the functions available in GAMBLR. There are also other convenient parameters for further customizing the returned plot. For example, we can label ASHM genes `(label_ashm_genes = TRUE)`, subset to specific chromosomes, zoom in to regions of interest. If plot is restricted to specific chromosomes or zoomed in to a region, we can also add SV labels, with the `labe_sv = TRUE`. In this example, we are looking at one sample (HTMCP-01-06-0042-01A-01D), all chromosomes with ASHM genes labeled. 
-```{r prettyRainfallPlot, dpi = 150, fig.height = 12, fig.width = 18, message = FALSE, warning = FALSE}
+```{r prettyRainfallPlot, fig.height = 12, fig.width = 18, fig.align = "center"}
 #build plot
 prettyRainfallPlot(this_sample_id = "HTMCP-01-06-00422-01A-01D",
                    seq_type = "genome",
@@ -300,7 +300,7 @@ prettyRainfallPlot(this_sample_id = "HTMCP-01-06-00422-01A-01D",
 
 ### Lollipop Plot
 The function `pretty_lollipop_plot` is perfect for creating an appealing, flexible and interactive HTML-style lollipop plot from mutational data using a modified version of g3Lollipop function from g3viz package. This function only takes for parameters; `maf_df` which is the data frame containing the mutations to be plotted. `gene` this parameter controls what gene to plot mutations for. Lastly, `plot_title` lets you specify the name of the plot and with `plot_theme` you can specify the plot theme. Please note that in order for this function to run, you must first installed the forked version of [g3viz](https://github.com/morinlab/g3viz/).  
-```{r pretty_lollipop_plot, dpi = 150, message = FALSE, warning = FALSE}
+```{r pretty_lollipop_plot}
 #get metadata (Fl and DLBCL) with pairing status matched 
 metadata = get_gambl_metadata() %>%
   dplyr::filter(pairing_status == "matched") %>%
@@ -320,7 +320,7 @@ pretty_lollipop_plot(maf_df = maf,
 
 ### Mutation Frequency Bin Matrix
 `get_mutation_frequency_bin_matrix` counts the number of mutations in a sliding window across a region for all samples (in the provided metadata parameter) and clusters the data.
-```{r get_mutation_frequency_bin_matrix, dpi = 150, fig.height = 12, fig.width = 18, warning = FALSE, message = FALSE}
+```{r get_mutation_frequency_bin_matrix, fig.height = 12, fig.width = 18, fig.align = "center"}
 #load metadata.
 dlbcl_bl_meta = get_gambl_metadata() %>%
     dplyr::filter(pathology %in% c("DLBCL",
@@ -379,7 +379,7 @@ get_mutation_frequency_bin_matrix(these_samples_metadata = dlbcl_bl_meta,
 
 ### Oncoplots
 Commonly, we will want to generate visualizations that only show genes deemed relevant for a given malignancy (and above some frequency threshold). For this purpose we have `prettyOncoplot` available. In the example bellow, we are looking at all coding SSM (genome samples) and the relevant genes for two malignancies (BL and DLBCL). This plotting function has a large collection of parameters that are available for further customization and manipulation of the returned plot. Please refer to the documentation for a complete explanation of each parameter. 
-```{r pretty_oncoplot_1, dpi = 150, fig.height = 12, fig.width = 18, warning = FALSE, message = FALSE}
+```{r pretty_oncoplot_1, fig.height = 12, fig.width = 18, fig.align = "center"}
 # Load the master merged MAF (coding only). It's usually more efficient to do this than to try to add filters to this query. Instead, just filter the data afterward
 maf_data = get_coding_ssm(seq_type = "genome")
 maf_metadata = get_gambl_metadata()
@@ -430,7 +430,7 @@ prettyOncoplot(maftools_obj = maf,
 ```
 
 As previous stated, `prettyOncoplot` has many parameters that can be called to further customize the plot and aggregate the data that are to be plotted. In reality, if all features of this plotting functions were to be demonstrated, a dedicated vignette for this purpose might be the way to go. Even so, here is another example were we include non coding regions (3' UTR, NFKBIZ).
-```{r pretty_oncoplot_2, dpi = 150, fig.height = 12, fig.width = 18, warning = FALSE, message = FALSE}
+```{r pretty_oncoplot_2, fig.height = 12, fig.width = 18, fig.align = "center"}
 #get SSM for NFKBIZ UTR region
 nfkbiz_utr_region = "chr3:101,578,185-101,579,902"
 nfkbiz_ssm = get_ssm_by_region(region = nfkbiz_utr_region, seq_type = "genome", projection = "grch37", basic_columns = TRUE)

--- a/vignettes/utilities_tutorial.Rmd
+++ b/vignettes/utilities_tutorial.Rmd
@@ -7,11 +7,10 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 ```{r setup, include = FALSE}
-knitr::opts_chunk$set(warning = FALSE, message = FALSE)
-options(bitmapType='cairo')
+knitr::opts_chunk$set(warning = FALSE, message = FALSE, fig.width = 7, fig.height = 5, fig.align = "center")
 ```
 
-```{r load_packages, message = FALSE, warning = FALSE, echo = FALSE, results = 'hide'}
+```{r load_packages, message = FALSE, warning = FALSE, echo = FALSE}
 library(GAMBLR)
 library(GAMBLR.data)
 library(tidyverse)
@@ -32,7 +31,7 @@ This section demonstrates how to return information related to genes and other s
 
 ### Gene To Region
 If you have a set of genes and you are interested in returning the genomic coordinates for these genes, it is recommended to call `gene_to_region`. This function takes four parameters; **gene_symbol**, a vector of on or more gene symbols in Hugo format. **ensembl_id**, a vector of one or more Ensembl IDs. **genome_build**, the desired projection for returned regions, acceptable values are hg38 and grch37. **return_as**, the format of returned regions, acceptable values are (1) **region** (a string formatted as chr:start-end), (2) **bed** and (3) **df**. Let's have a look at a few different examples, using a few different parameter combinations. 
-```{r gene_to_region, message = FALSE, warning = FALSE}
+```{r gene_to_region}
 #gene to region, for a single gene returned as "region"
 myc_region = gene_to_region(gene_symbol = "MYC", genome_build = "grch37", return_as = "region")
 
@@ -55,7 +54,7 @@ fl_genes_df = gene_to_region(gene_symbol = fl_genes, genome_build = "grch37", re
 
 ### Region To Gene
 Similarly, we can also return genes that are residing within a specified region. For this purpose `region_to_gene` was developed. This function operates in a similar way as the previous described function. Three parameters are available for this function; **region**, regions to intersect genes with, this can be either a data frame with regions sorted in the following columns; chromosome, start, end. Or it can be a character vector in "region" format, i.e chromosome:start-end.  **gene_format**, parameter for specifying the format of returned genes, default is "hugo", other acceptable inputs are "ensembl". **genome_build**, the desired projection for returned regions, acceptable values are hg38 and grch37. Here are a few examples showcasing how the different parameters can be used, as well as examples on how to make the most out of this function.
-```{r region_to_gene, message = FALSE, warning = FALSE}
+```{r region_to_gene}
 #simple example using a previously defined region (MYC)
 genes_in_this_region = region_to_gene(region = myc_region, gene_format = "hugo", genome_build = "grch37")
 
@@ -68,14 +67,14 @@ chr1q_genes = region_to_gene(region = "chr1:143200000-248956422", gene_format = 
 
 ### Regions To Bins
 This function was developed to split a contiguous genomic region on a chromosome into non-overlapping bins. This function takes four parameter; **chr**, **start**, **end**, and **bin_size**. In this example we are splitting the q-arm on chromosome 8 into bins of 20000 base pairs.
-```{r regions_to_bin, message = FALSE, warning = FALSE}
+```{r regions_to_bin}
 #regions to bin, bin chromosome 8 into 20000 bins
 chr8q_bins = region_to_bins(chromosome = "8", start = 48100000, end = 146364022, bin_size = 20000)
 ```
 
 ### Count SSM by Region
 Sometimes it can be helpful to tally all mutations (SSM) in a region for a set number of samples. To do so, one can call `count_ssm_by_region`. This function takes genomic coordinates either specified in region format (chr:start-end) with the `region` parameter, or the chromosome, start and end can be specified individually with the `chr`, `start`, and `end` parameters. In this example we are first creating a metadata subset, only including samples with FL as the pathology. Next, we are defining a region for MYC with help from `gene_to_region` with he return format specified as "region". The return is the sum of all SSMs overlapping with MYC for all FL samples.
-```{r count_ssm_by_region, message = FALSE, warning = FALSE}
+```{r count_ssm_by_region}
 #define a region.
 my_region = gene_to_region(gene_symbol = "MYC", return_as = "region")
 
@@ -99,9 +98,9 @@ coding_tabulated_df = get_coding_ssm_status(these_samples_metadata = my_metadata
 
 ### Calculate Proportion of Genome Altered by CNV
 Interested to see the percentage of a genome altered by CNVs for specific sample, or sample subsets? For this purpose `calcualte_pga` was developed. This function takes into account the total length of sample's CNV and relates it to the total genome length to return the proportion affected by CNV. The function can work with either individual or multi-sample seg files. The telomeres are always excluded from calculation, and centromeres/sex chromosomes can be optionally included or excluded.
-```{r calcualte_pga, warning = FALSE, message = FALSE}
+```{r calcualte_pga}
 #get CN segments for a specific sample.
-sample_seg = get_sample_cn_segments(this_sample_id = "14-36022T") %>% 
+sample_seg = get_sample_cn_segments(these_sample_ids = "14-36022T") %>% 
   dplyr::rename("sample" = "ID")
 
 #calculate PGA for the same sample.
@@ -110,14 +109,14 @@ calculate_pga(this_seg = sample_seg)
 
 ### Adjust Ploidy
 The `adjust_ploidy` function returns a seg file with log.ratios adjusted to the overall sample ploidy. This function adjusts the ploidy of the sample using the percent of genome altered (PGA). The PGA is calculated internally, but can also be optionally provided as data frame if calculated from other sources. Only the samples above the threshold-provided PGA (`pga_cutoff`) will have ploidy adjusted. The function can work with either individual or multi-sample seg file.
-```{r adjust_ploidy, warning = FALSE, message = FALSE}
+```{r adjust_ploidy}
 #ajdust ploidy
 adjust_ploidy(this_seg = sample_seg)
 ```
 
 ### Compare CNVs For Multiple Samples
 `cnvKompare` will compare CNV data between samples with multiple time points. It can also handle same-sample comparison between different CNV callers if the sample ID is specified in unique fashion. For groups with more than 2 samples, optionally pairwise comparisons can be performed. The comparison is made based on the internally calculated score, which reflects the percentage of each cytoband covered by CNV (rounded to the nearest 5%) and its absolute CN. Optionally, the heatmap of `cnvKompare` scores can be returned. In addition, the function will return all concordant and discordant cytobands. Finally, the time series plot of CNV log ratios will be returned for all lymphoma genes, with further functionality to subset it to a panel of genes of interest.
-```{r cnvKompare, message = FALSE, warning = FALSE}
+```{r cnvKompare, fig.height = 5, fig.width = 9, fig.align = "center"}
 #get CNV comparison data.
 kompare_out = cnvKompare(patient_id = "13-26835", 
                          projection = "hg38",
@@ -137,7 +136,7 @@ kompare_out$time_plot
 
 ### Genome to Exome
 If you are interested to subset a maf to only features that would be available in Whole Genome Exome (WEX) data, `genome_to_exome` is available for this purpose. This function takes the following parameters; `maf`, the incoming maf object. Can be maf-like data frame or maftools maf object. Minimum columns that should be present are Chromosome, Start_Position, and End_Position. `custom_bed`, optional argument specifying a path to custom bed file for covered regions. Must be bed-like and contain chrom, start, and end position information in first 3 columns. Other columns are disregarded if provided. `genome_build`, string indicating genome build of the maf file. Default is grch37, but can accept modifications of both grch37- and hg38-based builds. `padding`, numeric value that will be used to pad probes in WEX data from both ends. Default is 100. After padding, overlapping features are squished together. let's have a look at an example using this function.
-```{r genome_to_exome, message = FALSE, warning = FALSE}
+```{r genome_to_exome}
 #get all ssm in the MYC aSHM region
 myc_ashm_maf = get_ssm_by_region(region = "8:128748352-128749427")
 
@@ -148,7 +147,7 @@ wex = genome_to_exome(maf = myc_ashm_maf)
 ## Miscellaneous
 ### Collate Results
 Collate Results is used to retrieve a vast collection of sample-level results and summary data, generated by individual GAMBL pipelines. All in all, this function returns 89 variables (columns) for each sample ID (or more if you link it with metadata information!). This includes, but is not limited to the following information; various quality control (QC) metrics, mean VAF scores, total SSM/coding SSM, EBV information, mutation partners, and exposure to mutational signatures. Thus, this function can be a handy tool for retrieving and comparing sample-level results between different samples, cohorts, pathologies etc. The returned data is standardized in a way that also allows for straight forward plotting of the returned data. This function takes a variety of parameters that will be explained here. First, **sample_table** which is a data frame with sample IDs in the first column. This parameter is used to control for what samples you are retrieving collated results for. Another option for controlling the same variable is to use **these_samples_metadata**. This parameter takes a metadata table (ideally subset to the sample IDs of interest). If this parameter is called, it overwrites the `get_gambl_metadata` statement for when the user wants to join with metadata. Meaning if this parameter is set to `TRUE` and no **these_sample_metadata** is provided, it will link the collated results with all samples in the unfiltered meta data table. Other parameters include `write_to_file`, this parameter is Boolean parameter and if set to TRUE, it writes the results to disk (default is `FALSE`). Another parameter that is good to be aware of is `from_cache`, which controls how the function gets the results. Default is `TRUE`. In most user-cases, these two parameters should be run with their respective default values. Let's have a look at a few examples using this function.
-```{collate_results, message = FALSE, warning = FALSE}
+```{collate_results}
 #collate all genome samples, using cached results
 genome_collated = collate_results(seq_type_filter = "genome", from_cache = TRUE)
 
@@ -167,7 +166,7 @@ fl_collated = collate_results(sample_table = fl_samples, seq_type_filter = "geno
 ## Data Exports
 ### SV To bedpe
 This function takes an input SV data frame and writes it to a bedpe formatted file, that is compatible with the IGV genome browser. This function is rather straight forward, it expects a data frame with variant calls, it also takes a parameter called `file` which is the path to the to-be exported file. In addition, we also have `add_chr_prefix` that controls if the contigs should be prefixed with "chr", default is TRUE.
-```{r sv_to_bedpe_file, message = FALSE, warning = FALSE, eval = FALSE}
+```{r sv_to_bedpe_file, eval = FALSE}
 #get some SVs
 my_svs = get_manta_sv_by_sample(this_sample_id = "191621-PL01", these_samples_metadata = get_gambl_metadata(), force_lift = TRUE, projection = "hg38")
 
@@ -177,7 +176,7 @@ my_bedpe = sv_to_bedpe_file(sv_df = my_svs, add_chr_prefix = FALSE)
 
 ### SV To Custom Track
 Similarly, SVs can also be output as custom track for visualization on the UCSC genome Browser with `sv_to_custom_track`. This function takes an incoming SV data frame and outputs a bed file, ready for visualization on the UCSC Genome Browser. First, specify the output file with `output_file`. Next, indicate if the incoming SVs are annotated with `is_annotated` (default is TRUE). Lastly, the user can also specify if the incoming SV data frame should be subset to specific mutation types (e.g deletions, duplications, insertions, etc.) with the `sv_name` parameter. Default is to include all SV sub types.
-```{r sv_to_custom_track, warning = FALSE, message = FALSE, eval = FALSE}
+```{r sv_to_custom_track, eval = FALSE}
 #get SVs
 all_sv = get_combined_sv()
 
@@ -187,7 +186,7 @@ sv_to_custom_track(annotated_sv, output_file = "GAMBL_sv_custom_track_annotated.
  
 ### MAF To Custom Track
 In addition, we also have convenience functions available for generating custom tracks compatible with UCSC Genome Browser. This function offers a lot of flexibility in regards to the parameters at hand. For example, there are Boolean parameters dictating if output should be *bigbed* or *biglolly*. Parameters for specifying the custom fields of the output file are also available. Here is a straightforward example for output a maf data frame into a bed file for visualization on the Genome Browser.
-```{r maf_to_custom_track, message = FALSE, warning = FALSE, eval = FALSE}
+```{r maf_to_custom_track, eval = FALSE}
 #get some mutations
 my_mutations = get_ssm_by_region(region = "chr8:128723128-128774067")
 
@@ -198,7 +197,7 @@ my_bed = maf_to_custom_track(maf_data = my_mutations, colour_column = "Tumor_Sam
 ## Visualizations
 ### GAMBL Colours
 For your convenience, there is a dedicated GAMBL colour palette available. Useful for annotating figures in a standardized way. This function holds custom colour palettes for a variety of different applications and data subsets. To access all available palettes, one should start with `get_gambl_colours`. This function takes a few different parameters. The most important being, `clasification`. This parameter allows the user to return a palette for specific classifications (e.g pathology, lymphgen, mutation or copy_number, etc.). In addition, this function also have an `alpha` parameter for controlling the opacity of the returned colours. Another useful parameter for formatting the return, is `as_list`, and `as_dataframe`. If you want to return all available classification types, call this function with `return_available = TRUE`. Let's start with exploring a few of the different palettes, then let's arrange all colour palettes into a ggplot object for easy overview. 
-```{r get_gambl_colours, message = FALSE, warning = FALSE}
+```{r get_gambl_colours, fig.width = 7, fig.height = 10}
 #print all available classification columns
 get_gambl_colours(return_available = TRUE)
 
@@ -238,7 +237,7 @@ lapply(classes, function(x){plot_this_colour(this_group = x)})
 
 ### Gene Clouds
 Create a wordcloud from an incoming MAF with the `prettyGeneCloud` function. This function creates a figure with gene symbols from the provided maf, were the size of each printed gene symbol is proportional to the total n occurances in the maf. Required parameter is `maf_df`. Optional parameters are `these_genes`, `other_genes`, `these_genes_colour`, `other_genes_colour` and `colour_index`. If no genes are supplied when calling the function, this function will default to all lymphoma genes.
-```{r gene_cloud, message = FALSE, warning = FALSE}
+```{r gene_cloud}
 #get all coding SSM
 maf = get_coding_ssm(seq_type = "genome")
 


### PR DESCRIPTION
# Details
This PR introduces minor hotfixes related to multiple open issues on this repo. Here is a detailed description of what was fixed and how.

### get_sample_cn_segments has non-standard parameter naming (issue #224).
This function has been updated to work similarly to other GAMBLR functions with respect to what parameters to use for subset the return to specific sample IDs. In addition, the newly added helper function (`id_ease`) has also been implemented to streamline this process. Function docs and examples have all been updated to reflect the changes introduced in this PR. In-code reference to this function has also been updated throughout GAMBLR to make use of the new parameters.

### get_gambl_metadata broken for normals (issue #190).
This function has been updated to check the `tissue_status_filter` parameter. More specifically, if Normals are requested, and only normals this will be returned. The function works as expected when multiple elements are given to the parameter as well (i.e. `tissue_status_filter = c("tumour", "normal"))`. This fix also solves another issue (issue #225) reported on this repo (bug in `assign_cn_to_ssm`).

### Axis labels in plots generated by SSM vignette have extensively large fonts (issue #227).
The vignettes have been reworked to properly display the rendered figures. The issue was that some images got too compressed when knitted with default parameters (`width = 7` and `height = 5`). In addition, the chunk options in the vignette have been reduced and global knitting options are defined at the beginning of the vignette. Minor tweaks and edits to the vignettes are also included in this update.

In addition, a hotfix for `annotate_driver_ssm` is also introduced in this PR. This function was dependent on a now relocated bundled dataset if no genes were given to the `driver_genes` parameter. The function has been updated to now call the same dataset but from the correct location.

Lastly, the `smk` file used for syncing GAMBL data has also been updated to allow `get_manta_sv` to be run in a remote setting.

# Pull Request Checklists

**Important:** When opening a pull request, keep only the applicable checklist and delete all other sections.

## Checklist for all PRs

### Required

- [ ] I tested the new code for my use case (please provide a reproducible example of how you tested the new functionality)

- [ ] I ensured all dplyr functions that commonly conflict with other packages are fully qualified. 

This can be checked and addressed by running `check_functions.pl` and responding to the prompts. Test your code _after_ you do this.

- [ ] I generated the documentation and checked for errors relating to the new function (e.g. `devtools::document()`) and added `NAMESPACE` and all other modified files in the root directory and under `man`. 

### Optional but preferred with PRs

- [ ] I updated and/or successfully knitted a vignette that relies on the modified code (which ones?)

## Checklist for New Functions

### Required

- [ ] I documented my function using [Roxygen style](https://jozef.io/r102-addin-roxytags/#:~:text=Inserting%20a%20skeleton%20%2D%20Do%20this,Shift%2BAlt%2BR%20).)

- [ ] Adequate function documentation (see [new-function documentation template](https://github.com/morinlab/GAMBLR#title) for more info)

- [ ] I have ran `devtools::document()` to add the newly created function to NAMESPACE (do not manually add anything to this file!).

Example:
```
#' @title ASHM Rainbow Plot
#'
#' @description Make a rainbow plot of all mutations in a region, ordered and coloured by metadata.
#'
#' @details This function creates a rainbow plot for all mutations in a region. Region can either be specified with the `region` parameter,
#' or the user can provide a maf that has already been subset to the region(s) of interest with `mutation_maf`.
#' As a third alternative, the regions can also be specified as a bed file with `bed`.
#' Lastly, this function has a variety of parameters that can be used to further customize the returned plot in many different ways.
#' Refer to the parameter descriptions, examples as well as the vignettes for more demonstrations how this function can be called.
#'
#' @param mutations_maf A data frame containing mutations (MAF format) within a region of interest (i.e. use the get_ssm_by_region).
#' @param metadata should be a data frame with sample_id as a column.
#' @param exclude_classifications Optional argument for excluding specific classifications from a metadeta file.
#' @param drop_unmutated Boolean argument for removing unmutated sample ids in mutated cases.
#' @param classification_column The name of the metadata column to use for ordering and colouring samples.
#' @param bed Optional data frame specifying the regions to annotate (required columns: start, end, name).
#' @param region Genomic region for plotting in bed format.
#' @param custom_colours Provide named vector (or named list of vectors) containing custom annotation colours if you do not want to use standartized pallette.
#' @param hide_ids Boolean argument, if TRUE, ids will be removed.
#'
#' @return ggplot2 object.
#'
#' @import dplyr ggplot2
#' @export
#'
#' @examples
#' #basic usage
#' region = "chr6:90975034-91066134"
#' metadata = get_gambl_metadata()
#' plot = ashm_rainbow_plot(metadata = metadata, region = region)
#'
#' #advanced usages
#' mybed = data.frame(start = c(128806578,
#'                              128805652,
#'                              128748315),
#'                    end = c(128806992,
#'                            128809822,
#'                            128748880),
#'                    name = c("TSS",
#'                             "enhancer",
#'                             "MYC-e1"))
#'
#' ashm_rainbow_plot(mutations_maf = my_mutations,
#'                   metadata = my_metadata,
#'                   bed = mybed)
#'
```

- [ ] My function uses a library that isn't already a dependency of GAMBLR and I made the package aware of this dependency using the function documentation `import` statement. 

Example:
```
#' @return nothing
#' @export
#' @import tidyverse ggrepel
```

## Checklist for changes to existing code

- [ ] I added/removed arguments to a function and updated documentation for all changed/new arguments

- [ ] I tested the new code for compatibility with existing functionality in the Master branch (please provide a reprex of how you tested the original functionality)

