### PR TITLE
Vsouza add prefix gamblr.data

### DIFF
--- a/R/annotate_maf_triplet.R
+++ b/R/annotate_maf_triplet.R
@@ -21,7 +21,6 @@
 #' @examples
 #' annotate_maf_triplet(maf, all_SNVs = FALSE, "C", "T")
 #' 
-
 #This function gives triple sequence of provided mutated base
 annotate_maf_triplet = function(maf,
                                 all_SNVs = TRUE,

--- a/R/annotation.R
+++ b/R/annotation.R
@@ -509,8 +509,7 @@ annotate_sv = function(sv_data,
 #'           motif = "WRCY",
 #'           projection = "hg38"
 #'          )
-
-
+#'
 #This function check that if the motif pattern is in the sequence
 annotate_ssm_motif_context <- function(maf,
                      motif = "WRCY",

--- a/R/annotation.R
+++ b/R/annotation.R
@@ -291,7 +291,7 @@ annotate_driver_ssm = function(maf_df,
 
   #get the gene list if missing
   if(missing(driver_genes)){
-    driver_genes = lymphoma_genes[which(lymphoma_genes[[lymphoma_type]] == TRUE),] %>%
+    driver_genes = GAMBLR.data::lymphoma_genes[which(GAMBLR.data::lymphoma_genes[[lymphoma_type]] == TRUE),] %>%
       pull(Gene)
 
     ngene = length(driver_genes)
@@ -380,9 +380,9 @@ annotate_sv = function(sv_data,
   })
   if(missing(partner_bed)){
     if(genome_build == "hg38"){
-      ig_regions = hg38_partners
+      ig_regions = GAMBLR.data::hg38_partners
     }else{
-      ig_regions = grch37_partners
+      ig_regions = GAMBLR.data::grch37_partners
     }
   }else{
     ig_regions = partner_bed
@@ -391,9 +391,9 @@ annotate_sv = function(sv_data,
     }
   }
   if(genome_build == "hg38"){
-    oncogene_regions = hg38_oncogene
+    oncogene_regions = GAMBLR.data::hg38_oncogene
   }else{
-    oncogene_regions = grch37_oncogene
+    oncogene_regions = GAMBLR.data::grch37_oncogene
   }
   y = data.table::as.data.table(oncogene_regions)
   data.table::setkey(y, chrom, start, end)

--- a/R/calc_mutation_frequency_bin_region.R
+++ b/R/calc_mutation_frequency_bin_region.R
@@ -37,7 +37,6 @@
 #'                                                          slide_by = 10,
 #'                                                          window_size = 10000)
 #'
-
 calc_mutation_frequency_bin_region <- function(region,
                                           chromosome,
                                           start_pos,

--- a/R/database.R
+++ b/R/database.R
@@ -1745,7 +1745,7 @@ get_lymphgen = function(these_samples_metadata,
 #'
 #' @examples
 #' #basic usage, generic lymphoma gene list
-#' cn_matrix = get_cn_states(regions_bed=grch37_lymphoma_genes_bed)
+#' cn_matrix = get_cn_states(regions_bed=GAMBLR.data::grch37_lymphoma_genes_bed)
 #'
 #' myc_region <- gene_to_region(
 #'  gene_symbol = "MYC",
@@ -2214,7 +2214,7 @@ get_ashm_count_matrix = function(regions_bed,
     seq_type = head(these_samples_metadata) %>% pull(seq_type)
   }
   if(missing(regions_bed)){
-    regions_bed = grch37_ashm_regions
+    regions_bed = GAMBLR.data::grch37_ashm_regions
   }
   ashm_maf = get_ssm_by_regions(regions_bed = regions_bed,
                                 streamlined = TRUE,
@@ -2277,7 +2277,7 @@ get_ashm_count_matrix = function(regions_bed,
 #'
 #' @examples
 #' #basic usage, adding custom names from bundled ashm data frame
-#' regions_bed = dplyr::mutate(grch37_ashm_regions, name = paste(gene, region, sep = "_"))
+#' regions_bed = dplyr::mutate(GAMBLR.data::grch37_ashm_regions, name = paste(gene, region, sep = "_"))
 #'
 #' ashm_basic_details = get_ssm_by_regions(regions_bed = regions_bed)
 #'
@@ -2845,7 +2845,7 @@ get_gene_cn_and_expression = function(gene_symbol,
                                       this_seq_type = "genome"){
 
     if(!missing(gene_symbol)){
-      this_row = grch37_gene_coordinates %>%
+      this_row = GAMBLR.data::grch37_gene_coordinates %>%
         dplyr::filter(hugo_symbol == gene_symbol)
 
       this_region = paste0(this_row$chromosome, ":", this_row$start, "-", this_row$end)
@@ -2853,7 +2853,7 @@ get_gene_cn_and_expression = function(gene_symbol,
       }
 
     else{
-      this_row = grch37_gene_coordinates %>%
+      this_row = GAMBLR.data::grch37_gene_coordinates %>%
         dplyr::filter(ensembl_gene_id == ensembl_id)
 
       this_region = paste0(this_row$chromosome, ":", this_row$start, "-",this_row$end)

--- a/R/database.R
+++ b/R/database.R
@@ -1,6 +1,7 @@
-#global variables
 coding_class = c("Frame_Shift_Del", "Frame_Shift_Ins", "In_Frame_Del", "In_Frame_Ins", "Missense_Mutation", "Nonsense_Mutation", "Nonstop_Mutation", "Silent", "Splice_Region", "Splice_Site", "Targeted_Region", "Translation_Start_Site")
+
 cnames = c("CHROM_A", "START_A", "END_A", "CHROM_B", "START_B", "END_B", "NAME", "SOMATIC_SCORE", "STRAND_A", "STRAND_B", "TYPE", "FILTER", "VAF_tumour", "VAF_normal", "DP_tumour", "DP_normal", "tumour_sample_id", "normal_sample_id", "pair_status")
+
 maf_header = c("Hugo_Symbol"=1,"Entrez_Gene_Id"=2,"Center"=3,"NCBI_Build"=4,"Chromosome"=5,"Start_Position"=6,"End_Position"=7,"Strand"=8,"Variant_Classification"=9,"Variant_Type"=10,"Reference_Allele"=11,"Tumor_Seq_Allele1"=12,"Tumor_Seq_Allele2"=13,"dbSNP_RS"=14,"dbSNP_Val_Status"=15,"Tumor_Sample_Barcode"=16,"Matched_Norm_Sample_Barcode"=17,"Match_Norm_Seq_Allele1"=18,"Match_Norm_Seq_Allele2"=19,"Tumor_Validation_Allele1"=20,"Tumor_Validation_Allele2"=21,"Match_Norm_Validation_Allele1"=22,"Match_Norm_Validation_Allele2"=23,"Verification_Status"=24,"Validation_Status"=25,"Mutation_Status"=26,"Sequencing_Phase"=27,"Sequence_Source"=28,"Validation_Method"=29,"Score"=30,"BAM_File"=31,"Sequencer"=32,"Tumor_Sample_UUID"=33,"Matched_Norm_Sample_UUID"=34,"HGVSc"=35,"HGVSp"=36,"HGVSp_Short"=37,"Transcript_ID"=38,"Exon_Number"=39,"t_depth"=40,"t_ref_count"=41,"t_alt_count"=42,"n_depth"=43,"n_ref_count"=44,"n_alt_count"=45,"all_effects"=46,"Allele"=47,"Gene"=48,"Feature"=49,"Feature_type"=50,"Consequence"=51,"cDNA_position"=52,"CDS_position"=53,"Protein_position"=54,"Amino_acids"=55,"Codons"=56,"Existing_variation"=57,"ALLELE_NUM"=58,"DISTANCE"=59,"STRAND_VEP"=60,"SYMBOL"=61,"SYMBOL_SOURCE"=62,"HGNC_ID"=63,"BIOTYPE"=64,"CANONICAL"=65,"CCDS"=66,"ENSP"=67,"SWISSPROT"=68,"TREMBL"=69,"UNIPARC"=70,"RefSeq"=71,"SIFT"=72,"PolyPhen"=73,"EXON"=74,"INTRON"=75,"DOMAINS"=76,"AF"=77,"AFR_AF"=78,"AMR_AF"=79,"ASN_AF"=80,"EAS_AF"=81,"EUR_AF"=82,"SAS_AF"=83,"AA_AF"=84,"EA_AF"=85,"CLIN_SIG"=86,"SOMATIC"=87,"PUBMED"=88,"MOTIF_NAME"=89,"MOTIF_POS"=90,"HIGH_INF_POS"=91,"MOTIF_SCORE_CHANGE"=92,"IMPACT"=93,"PICK"=94,"VARIANT_CLASS"=95,"TSL"=96,"HGVS_OFFSET"=97,"PHENO"=98,"MINIMISED"=99,"GENE_PHENO"=100,"FILTER"=101,"flanking_bps"=102,"vcf_id"=103,"vcf_qual"=104,"gnomAD_AF"=105,"gnomAD_AFR_AF"=106,"gnomAD_AMR_AF"=107,"gnomAD_ASJ_AF"=108,"gnomAD_EAS_AF"=109,"gnomAD_FIN_AF"=110,"gnomAD_NFE_AF"=111,"gnomAD_OTH_AF"=112,"gnomAD_SAS_AF"=113,"vcf_pos"=114,"gnomADg_AF"=115,"blacklist_count"=116)
 
 
@@ -2832,7 +2833,7 @@ get_coding_ssm = function(limit_cohort,
 #' @param this_seq_type Seq type for returned CN segments. One of "genome" (default) or "capture".
 #'
 #' @return A data frame with copy number information and gene expressions.
-
+#'
 #' @import dplyr tibble
 #' @export
 #'

--- a/R/heatmap_mutation_frequency_bin.R
+++ b/R/heatmap_mutation_frequency_bin.R
@@ -60,7 +60,7 @@
 #'                                 these_samples_metadata = dlbcl_bl_meta)
 #'
 #' #get ashm regions
-#' some_regions = grch37_ashm_regions
+#' some_regions = GAMBLR.data::grch37_ashm_regions
 #'
 #' mut_count_matrix <- calc_mutation_frequency_bin_by_regions(
 #'    these_samples_metadata = dlbcl_bl_meta,

--- a/R/heatmap_mutation_frequency_bin.R
+++ b/R/heatmap_mutation_frequency_bin.R
@@ -67,8 +67,6 @@
 #'    regions_bed = some_regions
 #' )
 #'
-
-
 heatmap_mutation_frequency_bin <- function(
   regions_list = NULL,
   regions_bed = NULL,

--- a/R/portal.R
+++ b/R/portal.R
@@ -852,7 +852,7 @@ setup_expreession_data = function(project_name = "gambl_genome",
   
   #default to all lymphoma genes if no specific genes are supplied for getting expression values.
   if(missing(these_genes)){
-    these_genes = lymphoma_genes %>% pull(Gene)
+    these_genes = GAMBLR.data::lymphoma_genes %>% pull(Gene)
   }
   
   if(missing(expression_df)){

--- a/R/process_regions.R
+++ b/R/process_regions.R
@@ -26,7 +26,6 @@
 #' )
 #' regions_bed <- these_regions$regions_bed
 #' regions_vec <- these_regions$regions
-
 process_regions <- function(regions_list = NULL,
                             regions_bed = NULL,
                             region_padding = 0,

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1,7 +1,8 @@
-#global environment
 coding_class = c("Frame_Shift_Del", "Frame_Shift_Ins", "In_Frame_Del", "In_Frame_Ins", "Missense_Mutation", "Nonsense_Mutation", "Nonstop_Mutation", "Silent", "Splice_Region", "Splice_Site", "Targeted_Region", "Translation_Start_Site")
+
 rainfall_conv = c("T>C", "T>C", "C>T", "C>T", "T>A", "T>A", "T>G", "T>G", "C>A", "C>A", "C>G", "C>G", "InDel")
 names(rainfall_conv) = c('A>G', 'T>C', 'C>T', 'G>A', 'A>T', 'T>A', 'A>C', 'T>G', 'C>A', 'G>T', 'C>G', 'G>C', 'InDel')
+
 ssh_session <<- NULL
 
 
@@ -2831,7 +2832,7 @@ view_mutation_igv = function(this_mutation,
   }
 }
 
-socketWrite = function (sock, string) {
+socketWrite = function(sock, string){
   print(string)
   write.socket(sock, string)
   response <- read.socket(sock)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -372,10 +372,10 @@ gene_to_region = function(gene_symbol,
   
   #set mart based on selected genome projection
   if(genome_build == "grch37"){
-    gene_coordinates = grch37_gene_coordinates
+    gene_coordinates = GAMBLR.data::grch37_gene_coordinates
     chr_select = paste0(c(c(1:22),"X","Y"))
   }else{
-    gene_coordinates = hg38_gene_coordinates
+    gene_coordinates = GAMBLR.data::hg38_gene_coordinates
     chr_select = paste0("chr", c(c(1:22),"X","Y"))
   }
   
@@ -495,9 +495,9 @@ region_to_gene = function(region,
 
   #set mart based on selected genome projection
   if(genome_build == "grch37"){
-    gene_list = grch37_gene_coordinates
+    gene_list = GAMBLR.data::grch37_gene_coordinates
   }else if(genome_build == "hg38"){
-    gene_list = hg38_gene_coordinates
+    gene_list = GAMBLR.data::hg38_gene_coordinates
   }
 
   #rename columns to match downstream formats
@@ -691,7 +691,7 @@ get_coding_ssm_status = function(gene_symbols,
 
   if(missing(gene_symbols)){
     message("defaulting to all lymphoma genes")
-    gene_symbols = pull(lymphoma_genes, Gene)
+    gene_symbols = pull(GAMBLR.data::lymphoma_genes, Gene)
   }
 
   if(missing(these_samples_metadata)){
@@ -1090,9 +1090,9 @@ review_hotspots = function(annotated_maf,
   # check genome build because CREBBP coordinates are hg19-based or hg38-based
 
   if (genome_build %in% c("hg19", "grch37", "hs37d5", "GRCh37")){
-    coordinates = GAMBLR::hotspot_regions_grch37
+    coordinates = GAMBLR.data::hotspot_regions_grch37
   }else if(genome_build %in% c("hg38", "grch38", "GRCh38")){
-    coordinates = GAMBLR::hotspot_regions_hg38
+    coordinates = GAMBLR.data::hotspot_regions_hg38
   }else{
     stop("The genome build specified is not currently supported. Please provide MAF file in one of the following cordinates: hg19, grch37, hs37d5, GRCh37, hg38, grch38, or GRCh38")
   }
@@ -3285,9 +3285,9 @@ genome_to_exome = function(maf,
       if(! genome_build %in% c("hg19", "grch37", "hs37d5", "GRCh37", "hg38", "GRCh38", "grch38")){
         stop("The genome build specified is not currently supported. Please refer to genome build in one of the following cordinates: hg19, grch37, hs37d5, GRCh37, hg38, grch38, or GRCh38.")
       }else if(genome_build %in% c("hg19", "grch37", "hs37d5", "GRCh37")){
-        this_genome_coordinates = target_regions_grch37 # if the genome build is a flavour of hg19, get its exome space
+        this_genome_coordinates = GAMBLR.data::target_regions_grch37 # if the genome build is a flavour of hg19, get its exome space
       }else if(genome_build %in% c("hg38", "GRCh38", "grch38")){
-        this_genome_coordinates = target_regions_hg38 # exome space for the variations of hg38
+        this_genome_coordinates = GAMBLR.data::target_regions_hg38 # exome space for the variations of hg38
       }
   }else{
       this_genome_coordinates = fread(custom_bed)
@@ -3800,9 +3800,9 @@ calculate_pga = function(this_seg,
 
   # ensure the specified projection is correct and define chromosome coordinates
   if (projection == "grch37") {
-    chr_coordinates = chromosome_arms_grch37
+    chr_coordinates = GAMBLR.data::chromosome_arms_grch37
   } else if (projection == "hg38") {
-    chr_coordinates = chromosome_arms_hg38
+    chr_coordinates = GAMBLR.data::chromosome_arms_hg38
   } else {
     stop(
       "You specified projection that is currently not supported. Please provide seg files in either hg38 or grch37."
@@ -4313,10 +4313,10 @@ cnvKompare = function(patient_id,
   # VAF-like plot
   # genes
   if (projection %in% c("hg19", "grch37")) {
-    for_plot_lg = grch37_lymphoma_genes_bed %>%
+    for_plot_lg = GAMBLR.data::grch37_lymphoma_genes_bed %>%
       as.data.table()
   } else if (projection %in% c("hg38", "grch38")) {
-    for_plot_lg = hg38_lymphoma_genes_bed %>%
+    for_plot_lg = GAMBLR.data::hg38_lymphoma_genes_bed %>%
       as.data.table()
   }
   # did user specify particular genes of interest to display on the plot?

--- a/R/viz.R
+++ b/R/viz.R
@@ -372,7 +372,7 @@ gene_mutation_tally = function(maf_df,these_samples_metadata,these_genes,groupin
     dplyr::filter(Variant_Classification !="Silent")
   meta_anno = left_join(maf_filt,meta,by=c("Tumor_Sample_Barcode"="sample_id")) %>%
     group_by(Hugo_Symbol,Tumor_Sample_Barcode) %>%
-    slice_head() %>%
+    slice_head()
   meta_anno = left_join(maf_filt,meta,by=c("Tumor_Sample_Barcode"="sample_id")) %>%
     group_by(Hugo_Symbol,Tumor_Sample_Barcode) %>%
     slice_head() %>%

--- a/R/viz.R
+++ b/R/viz.R
@@ -74,13 +74,13 @@ prettyRainfallPlot = function(this_sample_id,
 
   if (label_ashm_genes) {
     if (projection == "grch37") {
-      ashm_regions = grch37_ashm_regions %>%
+      ashm_regions = GAMBLR.data::grch37_ashm_regions %>%
         dplyr::rename("start" = "hg19_start",
                       "end" = "hg19_end",
                       "Chromosome" = "chr_name") %>%
         dplyr::mutate(Chromosome = str_remove(Chromosome, pattern = "chr"))
     } else if (projection == "hg38") {
-      ashm_regions = hg38_ashm_regions %>%
+      ashm_regions = GAMBLR.data::hg38_ashm_regions %>%
         rename("start" = "hg38_start",
                "end" = "hg38_end",
                "Chromosome" = "chr_name")
@@ -422,7 +422,7 @@ prettyGeneCloud = function(maf_df,
                            other_genes_colour="#bc42f5",
                            colour_index){
   if(missing(these_genes)){
-    these_genes = pull(lymphoma_genes, Gene)
+    these_genes = pull(GAMBLR.data::lymphoma_genes, Gene)
   }
   #drop genes not in the list then tally only coding variants (by default).
   # TODO: eventually allow an option to collapse samples from the same patient
@@ -1024,7 +1024,7 @@ plot_sample_circos = function(this_sample_id,
    chrom_list = paste0("chr", c(1:22,"X"))
   }
   if(!missing(label_genes)){
-    gene_bed = grch37_gene_coordinates %>%
+    gene_bed = GAMBLR.data::grch37_gene_coordinates %>%
       dplyr::filter(gene_name %in% label_genes) %>%
       dplyr::select(chromosome, start, end, gene_name) %>%
       dplyr::mutate(chromosome = paste0("chr", chromosome))
@@ -1069,11 +1069,11 @@ plot_sample_circos = function(this_sample_id,
     colnames(anno_bed1) = c("chrom", "start", "end", "sample_id")
     colnames(anno_bed2) = c("chrom", "start", "end", "sample_id")
 
-    bed_mut_partner = grch37_partners %>%
+    bed_mut_partner = GAMBLR.data::grch37_partners %>%
       dplyr::filter(gene %in% these_partners) %>%
       mutate(chrom = paste0("chr", chrom))
 
-    bed_mut_onco = grch37_oncogene %>%
+    bed_mut_onco = GAMBLR.data::grch37_oncogene %>%
       dplyr::filter(gene %in% these_oncogenes) %>%
       mutate(chrom = paste0("chr", chrom))
 
@@ -2547,7 +2547,7 @@ prettyChromoplot = function(scores,
 
   #if no file is provided, annotate with oncogenes in GAMBLR package
   if(missing(genes_to_label)){
-    genes_to_label = GAMBLR::grch37_oncogene %>%
+    genes_to_label = GAMBLR.data::grch37_oncogene %>%
       dplyr::mutate(across(c(chrom, start, end), as.integer)) %>%
       data.table::as.data.table()
   }else{
@@ -4120,9 +4120,9 @@ fancy_ideogram = function(this_sample_id,
   }
 
   #grch37 coordinates
-  grch37_end = GAMBLR::chromosome_arms_grch37[c(2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44),3]
-  grch37_cent_start = GAMBLR::chromosome_arms_grch37[c(1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43),3]
-  grch37_cent_end = GAMBLR::chromosome_arms_grch37[c(2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44),2]
+  grch37_end = GAMBLR.data::chromosome_arms_grch37[c(2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44),3]
+  grch37_cent_start = GAMBLR.data::chromosome_arms_grch37[c(1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43),3]
+  grch37_cent_end = GAMBLR.data::chromosome_arms_grch37[c(2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44),2]
 
   #additional regions to plot
   if(!missing(gene_annotation)){
@@ -4454,9 +4454,9 @@ fancy_multisamp_ideogram = function(these_sample_ids,
     seg_dist = 0.12}
 
   #chr segment coordinates
-  grch37_end = GAMBLR::chromosome_arms_grch37[c(2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44),3]
-  grch37_cent_start = GAMBLR::chromosome_arms_grch37[c(1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43),3]
-  grch37_cent_end = GAMBLR::chromosome_arms_grch37[c(2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44),2]
+  grch37_end = GAMBLR.data::chromosome_arms_grch37[c(2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44),3]
+  grch37_cent_start = GAMBLR.data::chromosome_arms_grch37[c(1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43),3]
+  grch37_cent_end = GAMBLR.data::chromosome_arms_grch37[c(2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44),2]
 
   #build chr table for segment plotting
   chr = paste0("chr", c(1:22))

--- a/man/annotate_ssm_motif_context.Rd
+++ b/man/annotate_ssm_motif_context.Rd
@@ -39,4 +39,5 @@ annotate_ssm_motif_context (maf = maf,
           motif = "WRCY",
           projection = "hg38"
          )
+
 }

--- a/man/calc_mutation_frequency_bin_region.Rd
+++ b/man/calc_mutation_frequency_bin_region.Rd
@@ -37,6 +37,8 @@ calc_mutation_frequency_bin_region(
 
 \item{these_sample_ids}{Optional vector of sample IDs. Output will be subset to IDs present in this vector.}
 
+\item{this_seq_type}{Optional vector of seq_types to include in heatmap. Default c("genome", "capture"). Uses default seq_type priority for samples with >1 seq_type.}
+
 \item{maf_data}{Optional maf data frame. Will be subset to rows where Tumor_Sample_Barcode matches provided sample IDs or metadata table. If not provided, maf data will be obtained with get_ssm_by_regions().}
 
 \item{projection}{Specify which genome build to use. Required.}

--- a/man/calc_mutation_frequency_bin_regions.Rd
+++ b/man/calc_mutation_frequency_bin_regions.Rd
@@ -32,6 +32,8 @@ calc_mutation_frequency_bin_regions(
 
 \item{these_sample_ids}{Vector of sample IDs. Metadata will be subset to sample IDs present in this vector.}
 
+\item{this_seq_type}{Optional vector of seq_types to include in heatmap. Default c("genome", "capture"). Uses default seq_type priority for samples with >1 seq_type.}
+
 \item{maf_data}{Optional maf data frame. Will be subset to rows where Tumor_Sample_Barcode matches provided sample IDs or metadata table. If not provided, maf data will be obtained with get_ssm_by_regions().}
 
 \item{projection}{Genome build the function will operate in. Ensure this matches your provided regions and maf data for correct chr prefix handling. Default "grch37".}

--- a/man/get_cn_states.Rd
+++ b/man/get_cn_states.Rd
@@ -45,7 +45,7 @@ Is this function not what you are looking for? Try one of the following, similar
 }
 \examples{
 #basic usage, generic lymphoma gene list
-cn_matrix = get_cn_states(regions_bed=grch37_lymphoma_genes_bed)
+cn_matrix = get_cn_states(regions_bed=GAMBLR.data::grch37_lymphoma_genes_bed)
 
 myc_region <- gene_to_region(
  gene_symbol = "MYC",

--- a/man/get_ssm_by_regions.Rd
+++ b/man/get_ssm_by_regions.Rd
@@ -59,7 +59,7 @@ Is this function not what you are looking for? Try one of the following, similar
 }
 \examples{
 #basic usage, adding custom names from bundled ashm data frame
-regions_bed = dplyr::mutate(grch37_ashm_regions, name = paste(gene, region, sep = "_"))
+regions_bed = dplyr::mutate(GAMBLR.data::grch37_ashm_regions, name = paste(gene, region, sep = "_"))
 
 ashm_basic_details = get_ssm_by_regions(regions_bed = regions_bed)
 

--- a/man/heatmap_mutation_frequency_bin.Rd
+++ b/man/heatmap_mutation_frequency_bin.Rd
@@ -136,7 +136,7 @@ dlbcl_bl_meta = collate_results(join_with_full_metadata = TRUE,
                                 these_samples_metadata = dlbcl_bl_meta)
 
 #get ashm regions
-some_regions = grch37_ashm_regions
+some_regions = GAMBLR.data::grch37_ashm_regions
 
 mut_count_matrix <- calc_mutation_frequency_bin_by_regions(
    these_samples_metadata = dlbcl_bl_meta,

--- a/man/heatmap_mutation_frequency_bin.Rd
+++ b/man/heatmap_mutation_frequency_bin.Rd
@@ -5,10 +5,10 @@
 \title{Heatmap of mutation counts across sliding windows for multiple regions.}
 \usage{
 heatmap_mutation_frequency_bin(
-  regions = NULL,
+  regions_list = NULL,
   regions_bed = NULL,
   these_samples_metadata = NULL,
-  these_sample_id = NULL,
+  these_sample_ids = NULL,
   this_seq_type = c("genome", "capture"),
   maf_data,
   mut_freq_matrix,
@@ -44,15 +44,19 @@ heatmap_mutation_frequency_bin(
 )
 }
 \arguments{
-\item{regions}{Named vector of regions in the format c(name1 = "chr:start-end", name2 = "chr:start-end"). If neither regions nor regions_bed is specified, the function will use GAMBLR aSHM region information.}
+\item{regions_list}{Named vector of regions in the format c(name1 = "chr:start-end", name2 = "chr:start-end"). If neither regions nor regions_bed is specified, the function will use GAMBLR aSHM region information.}
 
 \item{regions_bed}{Data frame of regions with four columns (chrom, start, end, name).}
 
 \item{these_samples_metadata}{Metadata with at least sample_id column. If not providing a maf data frame, seq_type is also required.}
 
+\item{these_sample_ids}{Vector of sample IDs. Metadata will be subset to sample IDs present in this vector.}
+
+\item{this_seq_type}{Optional vector of seq_types to include in heatmap. Default c("genome", "capture"). Uses default seq_type priority for samples with >1 seq_type.}
+
 \item{maf_data}{Optional maf data frame. Will be subset to rows where Tumor_Sample_Barcode matches provided sample IDs or metadata table. If not provided, maf data will be obtained with get_ssm_by_regions().}
 
-\item{mut_freq_matrix}{Optional matrix of binned mutation frequencies generated outside of this function, usually by \link{calc_mutation_frequency_by_regions}.}
+\item{mut_freq_matrix}{Optional matrix of binned mutation frequencies generated outside of this function, usually by \link{calc_mutation_frequency_bin_regions}.}
 
 \item{projection}{Genome build the function will operate in. Ensure this matches your provided regions and maf data for correct chr prefix handling. Default grch37.}
 
@@ -111,8 +115,6 @@ heatmap_mutation_frequency_bin(
 \item{from_indexed_flatfile}{Set to TRUE to avoid using the database and instead rely on flat files (only works for streamlined data, not full MAF details).}
 
 \item{mode}{Only works with indexed flat files. Accepts 2 options of "slms-3" and "strelka2" to indicate which variant caller to use. Default is "slms-3".}
-
-\item{these_sample_ids}{Vector of sample IDs. Metadata will be subset to sample IDs present in this vector.}
 }
 \value{
 A table of mutation counts for sliding windows across one or more regions. May be long or wide.

--- a/resources/GAMBLR_presentation.Rmd
+++ b/resources/GAMBLR_presentation.Rmd
@@ -439,7 +439,7 @@ copy_number_vaf_plot(this_sample = "HTMCP-01-06-00422-01A-01D")
 ## Optional feature: coding mutation focus
 \tiny
 ```{r cn_vaf2, eval = FALSE, fig.height = 5, message = FALSE, warning = FALSE, include = TRUE, echo = TRUE}
-my_genes = lymphoma_genes %>% # Use the bundled list of lymphoma genes
+my_genes = GAMBLR.data::lymphoma_genes %>% # Use the bundled list of lymphoma genes
   dplyr::filter(BL == TRUE | DLBCL == TRUE) %>% 
   pull(Gene)
 

--- a/resources/test_functions.R
+++ b/resources/test_functions.R
@@ -22,7 +22,7 @@ myc_region = gene_to_region(gene_symbol = "MYC", genome_build = "grch37", return
 genes_bed = gene_to_region(gene_symbol = c("MYC", "BCL2"), genome_build = "hg38", return_as = "bed")
 
 #gene to region, for multiple genes specified in an already subseted list of gene names, return format is data frame
-fl_genes = dplyr::filter(lymphoma_genes, FL == TRUE) %>% pull(Gene)
+fl_genes = dplyr::filter(GAMBLR.data::lymphoma_genes, FL == TRUE) %>% pull(Gene)
 fl_genes_df = gene_to_region(gene_symbol = fl_genes, genome_build = "grch37", return_as = "df")
 
 #region to gene, simple example using a previously defined region (myc)
@@ -98,14 +98,14 @@ my_mutations = get_ssm_by_region(chromosome = "8", qstart = 128723128, qend = 12
 bcl2_all_details = get_ssm_by_region(region = "chr18:60796500-60988073", basic_columns = TRUE)
 
 #get ssm by region, this will get you the bare minimum basic 3-column information for mutated positions with non-MAF column naming
-regions_bed = grch37_ashm_regions %>% mutate(name = paste(gene, region, sep = "_")) %>% head(20)
+regions_bed = GAMBLR.data::grch37_ashm_regions %>% mutate(name = paste(gene, region, sep = "_")) %>% head(20)
 ashm_basic = get_ssm_by_regions(regions_bed = regions_bed)
 
 #get ssm byr region, you can get all the normal MAF columns and header this way:
 full_details_maf = get_ssm_by_regions(regions_bed = regions_bed, basic_columns = TRUE)
 
 #get ashm count matrix, functions that use this to do fun stuff:
-regions_bed = grch37_ashm_regions %>% mutate(name = paste(gene, region, sep = "_"))
+regions_bed = GAMBLR.data::grch37_ashm_regions %>% mutate(name = paste(gene, region, sep = "_"))
 matrix = get_ashm_count_matrix(regions_bed = head(regions_bed, 15), seq_type = "genome", these_samples_metadata = get_gambl_metadata() %>% dplyr::filter(pathology == "DLBCL"))
 
 #count ssm by region, example using minimal parameter as well as previously defined myc region
@@ -148,7 +148,7 @@ my_segments_2 = get_cn_segments(chromosome = "8", qstart = 128723128, qend = 128
 myc_cns = get_cn_segments(region = myc_region, projection = "grch37", this_seq_type = "genome", streamlined = FALSE, from_flatfile = TRUE, with_chr_prefix = FALSE) %>% dplyr::filter(CN != 2)
 
 #get cn states, this example uses the bundled bed file of regions containing lymphoma genes, warning: This is pretty slow with the full bed file
-cn_matrix = get_cn_states(regions_bed = head(grch37_lymphoma_genes_bed, 15))
+cn_matrix = get_cn_states(regions_bed = head(GAMBLR.data::grch37_lymphoma_genes_bed, 15))
 
 #get cn states, this will just get the matrix for FL cases
 cn_matrix = get_cn_states(these_samples_metadata = get_gambl_metadata() %>% dplyr::filter(pathology == "FL"), all_cytobands = TRUE, use_cytoband_name = TRUE)

--- a/resources/test_remote.R
+++ b/resources/test_remote.R
@@ -93,7 +93,7 @@ session = GAMBLR::get_ssh_session() # If your local machine username doesn't
 # match your GSC username, you need to add "<your_username>@gphost01.bcgsc.ca"
 # as the only argument to this function.
 test_ssm = get_ssm_by_samples(these_sample_ids = c("14-24534_tumorA","14-24534_tumorB"),
-                              ssh_session = session,subset_from_merge = T)
+                              subset_from_merge = T)
 
 table(test_ssm$Tumor_Sample_Barcode)
 
@@ -101,7 +101,7 @@ table(test_ssm$Tumor_Sample_Barcode)
 #11097           12904 
 
 test_ssm1 = get_ssm_by_patients(these_patient_ids =  c("14-24534"),
-                                ssh_session = session,subset_from_merge = F)
+                                subset_from_merge = F)
 
 table(test_ssm1$Tumor_Sample_Barcode) #should be the same
 
@@ -114,10 +114,10 @@ table(test_ssm1$Tumor_Sample_Barcode) #should be the same
 cn_seg = get_sample_cn_segments("14-24534_tumorB",from_flatfile = T)
 
 #should automagically get the single seg file and MAF for the sample
-cn_ssm = assign_cn_to_ssm("14-24534_tumorB",seg_file_source = "battenberg",ssh_session = session)
+cn_ssm = assign_cn_to_ssm("14-24534_tumorB", seg_file_source = "battenberg")
 
 
-pursteenah = estimate_purity(this_sample_id = "14-24534_tumorB",seg_file_source = "battenberg",ssh_session=session)
+pursteenah = estimate_purity(this_sample_id = "14-24534_tumorB", seg_file_source = "battenberg")
 
 pursteenah$sample_purity_estimation
 
@@ -176,8 +176,8 @@ fusion_samples = setup_fusions(human_friendly_name = "GAMBL genomes 2022 edition
               out_dir=cbio_path)
   
 all_samples = unique(c(samples_included,fusion_samples))
-finalize_study(seq_type_filter="genome",short_name="GAMBL_genome_2022",sample_ids=all_samples,
+finalize_study(seq_type_filter="genome", short_name="GAMBL_genome_2022", these_sample_ids=all_samples,
                human_friendly_name = "GAMBL genomes 2022 edition",
                project_name="gambl_genome_2022",
-               description = "GAMBL genome data",out_dir = cbio_path,overwrite = TRUE)
+               description = "GAMBL genome data", out_dir = cbio_path, overwrite = TRUE)
 


### PR DESCRIPTION
# Pull Request Checklists

## Checklist for all PRs

### Required

- [x] I tested the new code for my use case (please provide a reproducible example of how you tested the new functionality)

To test the new changes, I ran the scripts `resources/test_functions.R` and `resources/test_remote.R`.

I got these error messages from `resources/test_functions.R` (using GSC server), however they should not be related to any change in this PR:

```
### These errors can be fixed by specifying parameters `these_samples_metadata` and `these_sample_ids`.
### We decided to don't change this script, because we want to tweak `id_ease` function, which was changed
###   in a previous merged PR. 

all_sv = get_manta_sv()
# Error in id_ease(these_samples_metadata = these_samples_metadata, these_sample_ids = these_sample_ids,  : 
#   argument "these_samples_metadata" is missing, with no default

some_sv = get_manta_sv(these_sample_ids = "94-15772_tumorA")
# Error in id_ease(these_samples_metadata = these_samples_metadata, these_sample_ids = these_sample_ids,  : 
#   argument "these_samples_metadata" is missing, with no default

myc_locus_sv = get_manta_sv(region = "8:128723128-128774067")
# Error in id_ease(these_samples_metadata = these_samples_metadata, these_sample_ids = these_sample_ids,  : 
#   argument "these_samples_metadata" is missing, with no default
```

```
### I made the issue https://github.com/morinlab/GAMBLR/issues/243 for this error:

cn_matrix = get_cn_states(these_samples_metadata = get_gambl_metadata() %>% dplyr::filter(pathology == "FL"), all_cytobands = TRUE, use_cytoband_name = TRUE)
# Currently, only grch37 is supported                                                                                                         
# Cytobands are in respect to hg19. This will take awhile but it does work, trust me!
# Error in `[.data.frame`(cn_matrix, , region_names, drop = FALSE) :                                                                          
#   undefined columns selected
```

```
### I made the issue https://github.com/morinlab/GAMBLR/issues/244 for this error:

MYC_cn_expression = get_gene_cn_and_expression(gene_symbol = "MYC")
# [1] "grep -w -F -e Hugo_Symbol -e MYC /projects/nhl_meta_analysis_scratch/gambl/results_local/icgc_dart/DESeq2-0.0_salmon-1.0/mrna--gambl-icgc-all/vst-matrix-Hugo_Symbol_tidy.tsv"
# Error in `left_join()`:
#   ! Can't join `x$sample_id` with `y$genome_sample_id` due to incompatible types.
# ℹ `x$sample_id` is a <character>.
# ℹ `y$genome_sample_id` is a <logical>.
# Run `rlang::last_trace()` to see where the error occurred.
```

From `resources/test_remote.R`, these are the errors that I got when in remote mode. Again they should not be related to my changes in this PR:

```
### This error is due to a missing file in the GAMBLR installation on my desktop. Not related to this PR.

test_ssm = get_ssm_by_samples(these_sample_ids = c("14-24534_tumorA","14-24534_tumorB"),
                              subset_from_merge = T)
# using existing merge: /home/vladimir/repos/gambl_results/all_the_things/slms_3-1.0_vcf2maf-1.3/genome--projection/deblacklisted/augmented_maf/all_slms-3--grch37.maf
# [1] "missing:  /home/vladimir/repos/gambl_results/all_the_things/slms_3-1.0_vcf2maf-1.3/genome--projection/deblacklisted/augmented_maf/all_slms-3--grch37.maf"
# Cannot find file locally. If working remotely, perhaps you forgot to load your config (see below) or sync your files?
# Sys.setenv(R_CONFIG_ACTIVE = "remote")
# Error in data.table::fread(file = maf_file_path, sep = "\t", stringsAsFactors = FALSE,  : 
#   File '/home/vladimir/repos/gambl_results/all_the_things/slms_3-1.0_vcf2maf-1.3/genome--projection/deblacklisted/augmented_maf/all_slms-3--grch37.maf' does not exist or is non-readable. getwd()=='/# # home/vladimir/repos/gambl_results'
```

```
### Thanks Adam said these errors are fixed in his branch (https://github.com/morinlab/GAMBLR/pull/240).

cn_ssm = assign_cn_to_ssm("14-24534_tumorB",seg_file_source = "battenberg")
# Error in if (tissue_status_filter == "normal") { :
# the condition has length > 1

pursteenah = estimate_purity(this_sample_id = "14-24534_tumorB",seg_file_source = "battenberg")
# Error in if (tissue_status_filter == "normal") { :
# the condition has length > 1
```

```
### This is a warning, not an error. It doesn't look important to me.

finalize_study(seq_type_filter="genome",short_name="GAMBL_genome_2022",these_sample_ids=all_samples,
               human_friendly_name = "GAMBL genomes 2022 edition",
               project_name="gambl_genome_2022",
               description = "GAMBL genome data",out_dir = cbio_path,overwrite = TRUE)
# /home/vladimir/repos/gambl_results/shared/gambl_genome_results.tsv                                                                                                 
# Joining with `by = join_by(patient_id, sample_id, biopsy_id)`                                                                                                      
# Warning messages:                                                                                                                                                  
# 1: In write.table(meta_samples, file = clinsamp, sep = "\t", row.names = FALSE,  :
#   appending column names to file
# 2: In write.table(all_outcomes, file = clinpat, sep = "\t", row.names = FALSE,  :
#   appending column names to file
```

I also ran `resources/test_remote.R` on GSC server, these are the errors/warnings that I got. Again, not related to this PR:

```
### works with warnings

cn_ssm = assign_cn_to_ssm("14-24534_tumorB",seg_file_source = "battenberg")
# trying to find output from: battenberg                                                                                                          
# looking for flatfile: /projects/nhl_meta_analysis_scratch/gambl/results_local/gambl/battenberg_current/99-outputs/seg/genome--projection/14-24534_tumorB--14-24534_normal--matched.battenberg.grch37.seg
# Warning message:                                                                                                                                
# In if (tissue_status_filter == "normal") { :
#   the condition has length > 1 and only the first element will be used

pursteenah = estimate_purity(this_sample_id = "14-24534_tumorB",seg_file_source = "battenberg")
# trying to find output from: battenberg                                                                                                          
# looking for flatfile: /projects/nhl_meta_analysis_scratch/gambl/results_local/gambl/battenberg_current/99-outputs/seg/genome--projection/14-24534_tumorB--14-24534_normal--matched.battenberg.grch37.seg
# Warning message:                                                                                                                                
# In if (tissue_status_filter == "normal") { :
#   the condition has length > 1 and only the first element will be used
```

```
### `finalize_study` function wasn't run.
```