### PR TITLE
bug fix: fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `<img src="man/figures/logo.png" align="right" alt="" width="120" />`
+# <img src="man/figures/logo.png" align="right" alt="" width="120" />
 
 ![](https://github.com/morinlab/GAMBLR/actions/workflows/build_check.yml/badge.svg)
 


### PR DESCRIPTION
Fixing the readme logo issue. This is how it looks now
![image](https://github.com/morinlab/GAMBLR/assets/47579823/7420e6dd-f2bc-4a05-a7e2-3f6106c502f5)
